### PR TITLE
Refactored Renderer into Multiple Renderer Modules

### DIFF
--- a/shaders/billboard.frag
+++ b/shaders/billboard.frag
@@ -1,0 +1,9 @@
+#version 450
+
+layout (location = 0) in vec4 fragColor;
+
+layout (location = 0) out vec4 outColour;
+
+void main() {
+    outColour = fragColor;
+}

--- a/shaders/billboard.vert
+++ b/shaders/billboard.vert
@@ -1,0 +1,56 @@
+#version 450
+
+layout (location = 0) in vec3 position;
+layout (location = 1) in vec4 colour;
+
+layout (location = 0) out vec4 outColour;
+
+vec2 OFFSETS[4] = vec2[](
+    vec2(-0.5, -0.5),
+    vec2(-0.5, 0.5),
+    vec2(0.5, 0.5),
+    vec2(0.5, -0.5)
+);
+
+struct CameraData
+{
+    mat4 projectionMatrix;
+    mat4 viewMatrix;
+};
+
+struct LightData
+{
+    vec4 lightColor;
+    vec4 ambientLightColor;
+    vec3 position;
+};
+
+layout (set = 0, binding = 0) uniform GlobalData {
+    CameraData cameraData;
+    LightData lightData;
+} globalData;
+
+layout (std140, set = 1, binding = 1) readonly buffer ObjectBuffer {
+    vec3 positions[];
+} objectBuffer;
+
+mat4 view = globalData.cameraData.viewMatrix;
+mat4 projection = globalData.cameraData.projectionMatrix;
+
+void main() {
+
+    int index = int(floor(((gl_VertexIndex) / 4.0) - (int(gl_VertexIndex % 4 != 0) * 0.25)));
+    
+    vec3 worldPosition = objectBuffer.positions[index];
+
+    // Find the light position in camera space
+    vec4 lightInCameraSpace = view * vec4(position.xy + OFFSETS[gl_VertexIndex % 4], position.z, 1.0);
+
+    // Find the vertex position in camera space.
+    vec4 positionInCameraSpace = lightInCameraSpace + vec4(position, 1.0);
+
+    // Set the position to exist in camera space, not world space
+    gl_Position = projection * positionInCameraSpace;
+    
+    outColour = colour;
+}

--- a/shaders/billboard.vert
+++ b/shaders/billboard.vert
@@ -5,13 +5,6 @@ layout (location = 1) in vec4 colour;
 
 layout (location = 0) out vec4 outColour;
 
-vec2 OFFSETS[4] = vec2[](
-    vec2(-0.5, -0.5),
-    vec2(-0.5, 0.5),
-    vec2(0.5, 0.5),
-    vec2(0.5, -0.5)
-);
-
 struct CameraData
 {
     mat4 projectionMatrix;
@@ -25,13 +18,19 @@ struct LightData
     vec3 position;
 };
 
+struct BillboardData 
+{
+    vec3 position;
+    vec3 scale;
+};
+
 layout (set = 0, binding = 0) uniform GlobalData {
     CameraData cameraData;
     LightData lightData;
 } globalData;
 
 layout (std140, set = 1, binding = 1) readonly buffer ObjectBuffer {
-    vec3 positions[];
+    BillboardData data[];
 } objectBuffer;
 
 mat4 view = globalData.cameraData.viewMatrix;
@@ -39,18 +38,18 @@ mat4 projection = globalData.cameraData.projectionMatrix;
 
 void main() {
 
-    int index = int(floor(((gl_VertexIndex) / 4.0) - (int(gl_VertexIndex % 4 != 0) * 0.25)));
-    
-    vec3 worldPosition = objectBuffer.positions[index];
+    int index = int(floor((int(gl_VertexIndex) / 4.0) - (int(gl_VertexIndex % 4 != 0) * 0.25)));
+
+    BillboardData billboard = objectBuffer.data[index];
 
     // Find the light position in camera space
-    vec4 lightInCameraSpace = view * vec4(position.xy + OFFSETS[gl_VertexIndex % 4], position.z, 1.0);
+    vec4 lightInCameraSpace = view * vec4(billboard.position, 1.0);
 
     // Find the vertex position in camera space.
-    vec4 positionInCameraSpace = lightInCameraSpace + vec4(position, 1.0);
+    vec4 positionInCameraSpace = lightInCameraSpace + vec4(position.xy * (billboard.scale.xy * 0.5), 0.0, 0.0);
 
     // Set the position to exist in camera space, not world space
     gl_Position = projection * positionInCameraSpace;
-    
+
     outColour = colour;
 }

--- a/shaders/grid.frag
+++ b/shaders/grid.frag
@@ -1,0 +1,59 @@
+#version 450
+
+layout(location = 0) in vec3 fragColor;
+
+layout(location = 1) in vec3 nearPoint;
+layout(location = 2) in vec3 farPoint;
+layout(location = 3) in mat4 fragView;
+layout(location = 7) in mat4 fragProjection;
+
+layout(location = 0) out vec4 outColor;
+
+float near = 0.01; 
+float far = 2;
+
+vec2 vUV = vec2(4.0, 4.0);
+
+vec4 grid(vec3 fragPos3D, float scale) { 
+    vec2 coord = fragPos3D.xz * scale;
+    vec2 derivative = fwidth(coord);
+    vec2 grid = abs(fract(coord - 0.5) - 0.5) / derivative;
+    float line = min(grid.x, grid.y);
+    float minimumZ = min(derivative.y, 1);
+    float minimumX = min(derivative.x, 1);
+
+    vec4 color = vec4(0.2, 0.2, 0.2, 1.0 - min(line, 1.0));
+
+    color.z += (float(((fragPos3D.x > -1 * minimumX) && (fragPos3D.x < 1 * minimumX))) * 0.8);
+    color.x += (float(((fragPos3D.z > -1 * minimumZ) && (fragPos3D.z < 1 * minimumZ))) * 0.8);
+
+    return color;
+}
+
+float computeDepth(vec3 pos) {
+    vec4 clipSpacePos = fragProjection * fragView * vec4(pos.xyz, 1.0);
+    return (clipSpacePos.z / clipSpacePos.w);
+}
+
+float computeLinearDepth(vec3 pos) {
+    vec4 clipSpacePos = fragProjection * fragView * vec4(pos.xyz, 1.0);
+    float clipSpaceDepth = (clipSpacePos.z / clipSpacePos.w) * 2.0 - 1.0;
+    float linearDepth = (2.0 * near * far) / (far + near - clipSpaceDepth * (far - near));
+    return linearDepth / far;
+}
+
+
+void main() {
+
+    float t = -nearPoint.y / (farPoint.y - nearPoint.y);
+
+    vec3 fragPos3D = nearPoint + t * (farPoint - nearPoint);
+
+    gl_FragDepth = computeDepth(fragPos3D);
+
+    float linearDepth = computeLinearDepth(fragPos3D);
+    float fading = max(0, (0.5 - linearDepth));
+    
+    outColor = (grid(fragPos3D, 1) + grid(fragPos3D, 1))* float(t > 0);
+    outColor.a *= fading;
+}

--- a/shaders/grid.frag
+++ b/shaders/grid.frag
@@ -24,8 +24,8 @@ vec4 grid(vec3 fragPos3D, float scale) {
 
     vec4 color = vec4(0.2, 0.2, 0.2, 1.0 - min(line, 1.0));
 
-    color.z += (float(((fragPos3D.x > -1 * minimumX) && (fragPos3D.x < 1 * minimumX))) * 0.8);
-    color.x += (float(((fragPos3D.z > -1 * minimumZ) && (fragPos3D.z < 1 * minimumZ))) * 0.8);
+    color.z += (float(((fragPos3D.x > -1.0 * minimumX) && (fragPos3D.x < 1.0 * minimumX))) * 0.8);
+    color.x += (float(((fragPos3D.z > -1.0 * minimumZ) && (fragPos3D.z < 1.0 * minimumZ))) * 0.8);
 
     return color;
 }

--- a/shaders/grid.vert
+++ b/shaders/grid.vert
@@ -1,0 +1,63 @@
+#version 450
+
+const vec3 OFFSETS[6] = vec3[](
+    vec3(1, 1, 0), 
+    vec3(-1, -1, 0), 
+    vec3(-1, 1, 0),
+    vec3(-1, -1, 0), 
+    vec3(1, 1, 0), 
+    vec3(1, -1, 0)
+);
+
+layout(location = 0) out vec3 outColor;
+
+layout(location = 1) out vec3 nearPoint;
+layout(location = 2) out vec3 farPoint;
+
+layout(location = 3) out mat4 view;
+layout(location = 7) out mat4 projection;
+
+struct CameraData
+{
+    mat4 projectionMatrix;
+    mat4 viewMatrix;
+};
+
+struct LightData
+{
+    vec4 lightColor;
+    vec4 ambientLightColor;
+    vec3 position;
+};
+
+layout (set = 0, binding = 0) uniform GlobalData {
+    CameraData cameraData;
+    LightData lightData;
+} globalData;
+
+const vec3 scale = vec3(4.0, 4.0, 1.0);
+
+const vec3 position = vec3(0.0, 0.0, 0.0);
+
+CameraData camera = globalData.cameraData;
+
+vec3 unprojectPoint(float x, float y, float z, mat4 view, mat4 projection) {
+    mat4 viewInv = inverse(camera.viewMatrix);
+    mat4 projInv = inverse(camera.projectionMatrix);
+    vec4 unprojectedPoint = viewInv * projInv * vec4(x, y, z, 1.0);
+    return unprojectedPoint.xyz / unprojectedPoint.w;
+}
+
+void main() {
+    vec3 point = OFFSETS[gl_VertexIndex];
+
+    nearPoint = unprojectPoint(point.x, point.y, 0.0, camera.viewMatrix, camera.projectionMatrix);
+    farPoint = unprojectPoint(point.x, point.y, 1.0, camera.viewMatrix, camera.projectionMatrix);
+
+    view = camera.viewMatrix;
+    projection = camera.projectionMatrix;
+
+    gl_Position = vec4(point, 1.0);
+    outColor = vec3(1.0, 1.0, 1.0);
+}
+

--- a/shaders/line.vert
+++ b/shaders/line.vert
@@ -1,8 +1,9 @@
 #version 450
 
 layout(location = 0) in vec3 position;
+layout(location = 1) in vec3 colour;
 
-layout(location = 0) out vec3 outColor;
+layout(location = 0) out vec3 outColour;
 
 struct CameraData
 {
@@ -22,15 +23,10 @@ layout (set = 0, binding = 0) uniform GlobalData {
     LightData lightData;
 } globalData;
 
-layout (set = 1, binding = 1) uniform LineData
-{
-    vec3 color;
-} lineData;
-
 CameraData camera = globalData.cameraData;
 
 void main() {
     vec4 positionInWorldSpace = camera.projectionMatrix * camera.viewMatrix * vec4(position, 1.0);
     gl_Position = positionInWorldSpace;
-    outColor = lineData.color;
+    outColour = colour;
 }

--- a/src/Renderer/Material/Material.cpp
+++ b/src/Renderer/Material/Material.cpp
@@ -286,6 +286,7 @@ namespace SnekVk
         for(auto& property : propertiesArray)
         {
             if (id == property.id) {
+
                 Buffer::CopyData(buffer, dataSize, data, property.offset);
                 return;
             }

--- a/src/Renderer/Material/Material.h
+++ b/src/Renderer/Material/Material.h
@@ -26,7 +26,7 @@ namespace SnekVk
         enum Topology
         {
             LINE_LIST = 1,
-            LINE_STRING = 2,
+            LINE_STRIP = 2,
             TRIANGLE_LIST = 3
         };
 

--- a/src/Renderer/Mesh/Mesh.cpp
+++ b/src/Renderer/Mesh/Mesh.cpp
@@ -112,9 +112,12 @@ namespace SnekVk
 
     void Mesh::Bind(VkCommandBuffer commandBuffer)
     {
-        VkBuffer buffers[] = {vertexBuffer.buffer};
-        VkDeviceSize offsets[] = {0};
-        vkCmdBindVertexBuffers(commandBuffer, 0, 1, buffers, offsets);
+        if (vertexCount > 0)
+        {
+            VkBuffer buffers[] = {vertexBuffer.buffer};
+            VkDeviceSize offsets[] = {0};
+            vkCmdBindVertexBuffers(commandBuffer, 0, 1, buffers, offsets);
+        }
 
         if (hasIndexBuffer) vkCmdBindIndexBuffer(commandBuffer, indexBuffer.buffer, 0, VK_INDEX_TYPE_UINT32);
     }

--- a/src/Renderer/Mesh/Mesh.cpp
+++ b/src/Renderer/Mesh/Mesh.cpp
@@ -45,6 +45,7 @@ namespace SnekVk
             OUT globalStagingBuffer.buffer,
             OUT globalStagingBuffer.bufferMemory);
 
+        // TODO(Aryeh): Only create this if there actually are indices
         Buffer::CreateBuffer(
             sizeof(u32) * MAX_INDICES,
             VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
@@ -68,9 +69,13 @@ namespace SnekVk
     {
         Buffer::DestroyBuffer(vertexBuffer);
         Buffer::DestroyBuffer(globalStagingBuffer);
+        Buffer::DestroyBuffer(globalIndexStagingBuffer);
 
-        if (hasIndexBuffer) Buffer::DestroyBuffer(indexBuffer);
-
+        if (hasIndexBuffer) 
+        {
+            Buffer::DestroyBuffer(indexBuffer);
+        }
+        
         isFreed = true;
     }
 

--- a/src/Renderer/Mesh/Mesh.h
+++ b/src/Renderer/Mesh/Mesh.h
@@ -40,6 +40,7 @@ namespace SnekVk
         public:
 
         static constexpr size_t MAX_VERTICES = 10000;
+        static constexpr size_t MAX_INDICES = 100000;
 
         struct MeshData
         {
@@ -59,6 +60,10 @@ namespace SnekVk
 
         void LoadVertices(const Mesh::MeshData& meshData);
         void UpdateVertices(const Mesh::MeshData& meshData);
+
+        void UpdateVertexBuffer(const void* vertices);
+        void UpdateIndexBuffer(u32* indices);
+
         void Bind(VkCommandBuffer commandBuffer);
         void DestroyMesh();
 
@@ -78,13 +83,16 @@ namespace SnekVk
         void CreateIndexBuffer(const u32* indices);
 
         Buffer::Buffer globalStagingBuffer;
+        Buffer::Buffer globalIndexStagingBuffer;
 
         Buffer::Buffer vertexBuffer;
-        u32 vertexCount = 0;
+        Buffer::Buffer indexBuffer;
 
         bool hasIndexBuffer = false;
-        Buffer::Buffer indexBuffer;
+        bool hasVertexBuffer = false;
+
         u32 indexCount = 0;
+        u32 vertexCount = 0;
 
         u64 vertexSize = 0;
 

--- a/src/Renderer/Pipeline/PipelineConfig.h
+++ b/src/Renderer/Pipeline/PipelineConfig.h
@@ -12,7 +12,8 @@ namespace SnekVk
         enum AttributeType
         {
             VEC2 = VK_FORMAT_R32G32_SFLOAT,
-            VEC3 = VK_FORMAT_R32G32B32_SFLOAT
+            VEC3 = VK_FORMAT_R32G32B32_SFLOAT,
+            VEC4 = VK_FORMAT_R32G32B32A32_SFLOAT
         };
 
         enum InputRate

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -52,16 +52,13 @@ namespace SnekVk
     {
         auto commandBuffer = GetCurrentCommandBuffer();
 
-        Renderer3D::GlobalData global3DData = {
-            { mainCamera->GetProjection(), mainCamera->GetView()},
-            light->GetLightData()
-        };
+        CameraData cameraData = { mainCamera->GetProjection(), mainCamera->GetView()};
 
         Renderer2D::GlobalData global2DData = {
-            { mainCamera->GetProjection(), mainCamera->GetView()}
+            { cameraData }
         };
 
-        Renderer3D::Render(commandBuffer, global3DData);
+        Renderer3D::Render(commandBuffer, cameraData);
         Renderer2D::Render(commandBuffer, global2DData);
     }
 

--- a/src/Renderer/Renderer.h
+++ b/src/Renderer/Renderer.h
@@ -35,7 +35,6 @@ namespace SnekVk
             float GetAspectRatio() const { return swapChain.ExtentAspectRatio(); }
 
             void SetMainCamera(Camera* camera) { mainCamera = camera; }
-            void SetPointLight(PointLight* light) { this->light = light;}
             
             bool IsFrameStarted() { return isFrameStarted; }
 
@@ -70,8 +69,6 @@ namespace SnekVk
 
             void DrawFrame();
 
-            PipelineConfigInfo CreateDefaultPipelineConfig();
-
             SnekVk::Window& window;
             
             VulkanDevice device;
@@ -82,6 +79,5 @@ namespace SnekVk
             int currentFrameIndex{0};
 
             Camera* mainCamera;
-            PointLight* light;
     };
 }

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -110,11 +110,6 @@ namespace SnekVk
         DrawModel(model, position, glm::vec3{1.f}, glm::vec3{0.f});
     }
 
-    void Renderer3D::DrawBillboard(Model* model, const glm::vec3& position, const glm::vec2& scale, const float& rotation)
-    {
-        
-    }
-
     void Renderer3D::DrawLight(Model* model)
     {
         lightModel = model;

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -87,7 +87,9 @@ namespace SnekVk
         debugRenderer.Render(commandBuffer, globalDataSize, &globalData);
         billboardRenderer.Render(commandBuffer, globalDataSize, &globalData);
         
-        if (gridEnabled) RenderGrid(commandBuffer, globalData);
+        #ifdef ENABLE_GRID
+        RenderGrid(commandBuffer, globalData);
+        #endif
 
         currentModel = nullptr;
         currentMaterial = nullptr;

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -291,20 +291,50 @@ namespace SnekVk
     {   
         AddWireQuad(
         {
-            gridData.nextTopRightIndex, 
+            gridData.nextTopRightIndex + 3, 
+            gridData.nextBottomRightIndex + 3,
             gridData.nextBottomRightIndex,
-            gridData.nextBottomRightIndex,
-        }, 3);
+        }, 
+        {
+            gridData.vertices[gridData.nextTopRightIndex],
+            gridData.vertices[gridData.nextBottomRightIndex]
+        }, 
+        {
+            gridData.nextTopLeftIndex,
+            gridData.nextTopRightIndex + 3,
+            gridData.nextBottomRightIndex + 3,
+            gridData.nextBottomLeftIndex
+        }, 
+        {
+            gridData.gridScale.x,
+            0.f, 
+            0.f
+        });
 
         for(size_t i = 2; i < gridData.rows; i++)
         {
             bool isEven = i % 2 == 0;
 
             AddWireQuad({
-                isEven ? gridData.nextBottomRightIndex : gridData.nextTopRightIndex,
-                isEven ? gridData.nextTopRightIndex : gridData.nextBottomRightIndex,
-                isEven ? gridData.nextTopRightIndex : gridData.nextBottomRightIndex
-            }, 2);
+                (isEven * gridData.nextBottomRightIndex) + (!isEven * gridData.nextTopRightIndex) + 2,
+                (isEven * gridData.nextTopRightIndex) + (!isEven * gridData.nextBottomRightIndex) + 2,
+                (isEven * gridData.nextTopRightIndex) + (!isEven * gridData.nextBottomRightIndex)
+            }, 
+            {
+                gridData.vertices[gridData.nextTopRightIndex],
+                gridData.vertices[gridData.nextBottomRightIndex]
+            }, 
+            {
+                gridData.nextTopLeftIndex,
+                gridData.nextTopRightIndex + 2,
+                gridData.nextBottomRightIndex + 2,
+                gridData.nextBottomLeftIndex
+            }, 
+            {
+                gridData.gridScale.x,
+                0.f, 
+                0.f,
+            });
         }
 
         // Reset to first quad for this row.
@@ -319,67 +349,100 @@ namespace SnekVk
     {
         u32 start = 0;
 
-        start = gridData.rows % 2 == 0 ? gridData.nextBottomLeftIndex : gridData.nextTopLeftIndex;
+        bool isEven = gridData.rows % 2 == 0;
+        
+        // First Quad
+        start = (isEven * gridData.nextBottomLeftIndex) + (!isEven * gridData.nextTopLeftIndex);
 
-        gridData.indices[gridData.indexCount++] = start;
-        gridData.indices[gridData.indexCount++] = (gridData.rows * 2) + 2;
-        gridData.indices[gridData.indexCount++] = (gridData.rows * 2) + 3;
-        gridData.indices[gridData.indexCount++] = gridData.nextBottomRightIndex;
+        glm::vec3 bottomRightPosition = gridData.vertices[gridData.nextBottomRightIndex];
 
-        glm::vec3 bottomLeftVertexPosition = gridData.vertices[gridData.nextBottomLeftIndex];
-        glm::vec3 bottomRightVertexPosition = gridData.vertices[gridData.nextBottomRightIndex];
+        AddWireQuad(
+        {
+            start, 
+            (gridData.rows * 2) + 2,
+            (gridData.rows * 2) + 3,
+            gridData.nextBottomRightIndex
+        }, 
+        {
+            gridData.vertices[gridData.nextBottomLeftIndex],
+            gridData.vertices[gridData.nextBottomRightIndex],
+        }, 
+        {
+            gridData.nextTopLeftIndex,
+            gridData.nextBottomRightIndex + 3,
+            (gridData.rows * 2) + 4,
+            (gridData.rows * 2) + 3
+        },
+        {
+            0.f, 
+            gridData.gridScale.y,
+            0.f
+        });
 
-        bottomLeftVertexPosition.y += gridData.gridScale.y;
-        bottomRightVertexPosition.y += gridData.gridScale.y;
+        bottomRightPosition.y += gridData.gridScale.y;
 
-        gridData.vertices[gridData.vertexCount++] = bottomLeftVertexPosition;
-        gridData.vertices[gridData.vertexCount++] = bottomRightVertexPosition;
+        AddWireQuad(
+        {
+            gridData.nextTopRightIndex,
+            gridData.nextBottomRightIndex,
+            gridData.nextBottomLeftIndex, 
+        }, 
+        {
+            bottomRightPosition
+        }, 
+        {
+            gridData.nextTopLeftIndex,
+            gridData.nextTopRightIndex + 2,
+            gridData.nextBottomRightIndex + 1,
+            gridData.nextBottomLeftIndex + 1,
+        },
+        {
+            gridData.gridScale.x, 
+            0.f,
+            0.f
+        });
 
-        // Next Quad
-        gridData.nextTopRightIndex = gridData.nextBottomRightIndex + 3;
-        gridData.nextBottomRightIndex = (gridData.rows * 2) + 4;
-        gridData.nextBottomLeftIndex = (gridData.rows * 2) + 3;
+        bottomRightPosition.x += gridData.gridScale.x;
 
-        gridData.indices[gridData.indexCount++] = gridData.nextTopRightIndex;
-        gridData.indices[gridData.indexCount++] = gridData.nextBottomRightIndex;
-        gridData.indices[gridData.indexCount++] = gridData.nextBottomLeftIndex;
+        AddWireQuad(
+        {
+            gridData.nextBottomRightIndex,
+            gridData.nextTopRightIndex,
+        }, 
+        {
+            bottomRightPosition
+        }, 
+        {
+            gridData.nextTopLeftIndex,
+            gridData.nextTopRightIndex + 2,
+            gridData.nextBottomRightIndex + 1,
+            gridData.nextBottomLeftIndex + 1,
+        },
+        {
+            gridData.gridScale.x, 
+            0.f,
+            0.f
+        });
 
-        bottomRightVertexPosition.x += gridData.gridScale.x;
-        gridData.vertices[gridData.vertexCount++] = bottomRightVertexPosition;
-
-        // Next Quad
-        gridData.nextTopRightIndex = gridData.nextTopRightIndex + 2;
-        gridData.nextBottomRightIndex += 1;
-        gridData.nextBottomLeftIndex += 1;
-
-        gridData.indices[gridData.indexCount++] = gridData.nextBottomRightIndex;
-        gridData.indices[gridData.indexCount++] = gridData.nextTopRightIndex;
-
-        bottomRightVertexPosition.x += gridData.gridScale.x;
-        gridData.vertices[gridData.vertexCount++] = bottomRightVertexPosition;
+        bottomRightPosition.x += gridData.gridScale.x;
     }
 
-    void Renderer3D::AddWireQuad(std::initializer_list<u32> indices, const u32 indexModifier)
+    void Renderer3D::AddWireQuad(std::initializer_list<u32> indices, std::initializer_list<glm::vec3> vertices, const QuadIndexExtents& extentIndices, const glm::vec3& scale)
     {
-        glm::vec3 topRightVertexPosition = gridData.vertices[gridData.nextTopRightIndex];
-        glm::vec3 bottomRightVertexPosition = gridData.vertices[gridData.nextBottomRightIndex];
-
         for (auto& index: indices)
         {
-            u32 modifiedIndex = index; 
-
-            if (&index != (indices.begin()+indices.size()-1)) modifiedIndex += indexModifier;
-            gridData.indices[gridData.indexCount++] = modifiedIndex;
+            gridData.indices[gridData.indexCount++] = index;
         }
 
-        topRightVertexPosition.x += gridData.gridScale.x;
-        bottomRightVertexPosition.x += gridData.gridScale.x;
+        for (auto& vertex : vertices)
+        {
+            gridData.vertices[gridData.vertexCount++] = vertex + scale; 
+        }
 
-        gridData.vertices[gridData.vertexCount++] = topRightVertexPosition;
-        gridData.vertices[gridData.vertexCount++] = bottomRightVertexPosition;
-
-        gridData.nextTopRightIndex += indexModifier;
-        gridData.nextBottomRightIndex += indexModifier;
+        gridData.nextTopLeftIndex = extentIndices.topLeft;
+        gridData.nextTopRightIndex = extentIndices.topRight;
+        gridData.nextBottomRightIndex = extentIndices.bottomRight;
+        gridData.nextBottomLeftIndex = extentIndices.bottomLeft;
     }
 
     void Renderer3D::RecreateMaterials()

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -4,21 +4,11 @@
 namespace SnekVk
 {
     // static initialisation
-    Utils::StringId Renderer3D::transformId;
     Utils::StringId Renderer3D::globalDataId;
-
-    u64 Renderer3D::transformSize = sizeof(Model::Transform) * MAX_OBJECT_TRANSFORMS;
-
-    Utils::StackArray<Model::Transform, Renderer3D::MAX_OBJECT_TRANSFORMS> Renderer3D::transforms;
-    Utils::StackArray<Model*, Renderer3D::MAX_OBJECT_TRANSFORMS> Renderer3D::models;
-
-    Material* Renderer3D::currentMaterial = nullptr;
-    Model* Renderer3D::currentModel = nullptr;
-
-    Model* Renderer3D::lightModel = nullptr;
 
     Material Renderer3D::gridMaterial;
 
+    ModelRenderer Renderer3D::modelRenderer;
     DebugRenderer3D Renderer3D::debugRenderer;
     BillboardRenderer Renderer3D::billboardRenderer;
     LightRenderer Renderer3D::lightRenderer;
@@ -27,9 +17,9 @@ namespace SnekVk
 
     void Renderer3D::Initialise()
     {
-        transformId = INTERN_STR("objectBuffer");
         globalDataId = INTERN_STR("globalData");
 
+        modelRenderer.Initialise("globalData", sizeof(GlobalData));
         debugRenderer.Initialise("globalData", sizeof(GlobalData));
         billboardRenderer.Initialise("globalData", sizeof(GlobalData));
         lightRenderer.Initialise("globalData", sizeof(GlobalData));
@@ -48,18 +38,14 @@ namespace SnekVk
         gridMaterial.BuildMaterial();
     }
 
-    void Renderer3D::DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation)
-    {
-        models.Append(model);
-
-        auto transform = Utils::Math::CalculateTransform3D(position, rotation, scale);
-        auto normal = Utils::Math::CalculateNormalMatrix(rotation, scale);
-        transforms.Append({transform, normal});
-    }
-
     void Renderer3D::DrawBillboard(const glm::vec3& position, const glm::vec2& scale, const glm::vec4& colour)
     {
         billboardRenderer.DrawBillboard(position, scale, colour);
+    }
+
+    void Renderer3D::DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation)
+    {
+        modelRenderer.DrawModel(model, position, scale, rotation);
     }
 
     void Renderer3D::DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale)
@@ -72,7 +58,7 @@ namespace SnekVk
         DrawModel(model, position, glm::vec3{1.f}, glm::vec3{0.f});
     }
 
-    void Renderer3D::DrawLight(const glm::vec3& position, const float& radius, const glm::vec4& colour, const glm::vec4& ambientColor)
+    void Renderer3D::DrawPointLight(const glm::vec3& position, const float& radius, const glm::vec4& colour, const glm::vec4& ambientColor)
     {   
         global3DData.lightData = {colour, ambientColor, position};
 
@@ -81,14 +67,10 @@ namespace SnekVk
 
     void Renderer3D::Render(VkCommandBuffer& commandBuffer, const CameraData& cameraData)
     {
-        if (models.Count() == 0) return;
-
         global3DData.cameraData = cameraData;
-
         u64 globalDataSize = sizeof(global3DData);
 
-        RenderModels(commandBuffer, global3DData);
-
+        modelRenderer.Render(commandBuffer, globalDataSize, &global3DData);
         lightRenderer.Render(commandBuffer, globalDataSize, &global3DData);
         debugRenderer.Render(commandBuffer, globalDataSize, &global3DData);
         billboardRenderer.Render(commandBuffer, globalDataSize, &global3DData);
@@ -96,53 +78,11 @@ namespace SnekVk
         #ifdef ENABLE_GRID
         RenderGrid(commandBuffer, global3DData);
         #endif
-
-        currentModel = nullptr;
-        currentMaterial = nullptr;
     }
 
     void Renderer3D::DrawLine(const glm::vec3& origin, const glm::vec3& destination, const glm::vec3& colour)
     {
         debugRenderer.DrawLine(origin, destination, colour);
-    }
-
-    void Renderer3D::RenderModels(VkCommandBuffer& commandBuffer, const GlobalData& globalData)
-    {
-        for (size_t i = 0; i < models.Count(); i++)
-        {
-            auto& model = models.Get(i);
-
-            if (currentMaterial != model->GetMaterial())
-            {
-                currentMaterial = model->GetMaterial();
-                currentMaterial->SetUniformData(transformId, transformSize, transforms.Data());
-                currentMaterial->SetUniformData(globalDataId, sizeof(globalData), &globalData);
-                currentMaterial->Bind(commandBuffer);
-            } 
-
-            if (currentModel != model)
-            {
-                currentModel = model;
-                currentModel->Bind(commandBuffer);
-            }
-
-            model->Draw(commandBuffer, i);
-        }
-    }
-    
-    void Renderer3D::RenderLights(VkCommandBuffer& commandBuffer, const GlobalData& globalData)
-    {
-        if (lightModel == nullptr) return; 
-
-        auto lightMaterial = lightModel->GetMaterial();
-
-        if (lightMaterial == nullptr) return;
-
-        lightMaterial->SetUniformData(globalDataId, sizeof(globalData), &globalData);
-        lightMaterial->Bind(commandBuffer);
-
-        lightModel->Bind(commandBuffer);
-        lightModel->Draw(commandBuffer, 0);
     }
 
     void Renderer3D::RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData)
@@ -155,8 +95,7 @@ namespace SnekVk
 
     void Renderer3D::RecreateMaterials()
     {
-        if (currentMaterial) currentMaterial->RecreatePipeline(); 
-
+        modelRenderer.RecreateMaterials();
         debugRenderer.RecreateMaterials();
         billboardRenderer.RecreateMaterials();
         lightRenderer.RecreateMaterials();
@@ -166,16 +105,15 @@ namespace SnekVk
 
     void Renderer3D::Flush()
     {
+        modelRenderer.Flush();
         debugRenderer.Flush();
         billboardRenderer.Flush();
         lightRenderer.Flush();
-
-        transforms.Clear();
-        models.Clear();
     }
 
     void Renderer3D::DestroyRenderer3D()
     {
+        modelRenderer.Destroy();
         debugRenderer.Destroy();
         billboardRenderer.Destroy();
         lightRenderer.Destroy();

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -98,16 +98,6 @@ namespace SnekVk
         debugRenderer.DrawLine(origin, destination, colour);
     }
 
-    // void Renderer3D::DrawRect(const glm::vec3& position, const glm::vec2& scale, glm::vec3 color)
-    // {
-    //     rects.Append({position.x - (scale.x / 2.0), position.y + (scale.y / 2.0), position.z});
-    //     rects.Append({position.x + (scale.x / 2.0), position.y + (scale.y / 2.0), position.z});
-    //     rects.Append({position.x + (scale.x / 2.0), position.y - (scale.y / 2.0), position.z});
-    //     rects.Append({position.x - (scale.x / 2.0), position.y - (scale.y / 2.0), position.z});
-
-    //     lineData = color;
-    // }
-
     void Renderer3D::RenderModels(VkCommandBuffer& commandBuffer, const GlobalData& globalData)
     {
         for (size_t i = 0; i < models.Count(); i++)
@@ -132,7 +122,6 @@ namespace SnekVk
         }
     }
     
-    // TODO(Aryeh): This is rendering a billboard. Might want to defer this to a billboard renderer
     void Renderer3D::RenderLights(VkCommandBuffer& commandBuffer, const GlobalData& globalData)
     {
         if (lightModel == nullptr) return; 

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -150,31 +150,12 @@ namespace SnekVk
         gridEnabled = true;
     }
 
-    // void Renderer3D::RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData)
-    // {
-    //     rectMaterial.SetUniformData(globalDataId, sizeof(globalData), &globalData);
-    //     rectMaterial.SetUniformData("lineData", sizeof(glm::vec3), &lineData);
-    //     rectMaterial.Bind(commandBuffer);
-
-    //     u32 indices[] = {0, 1, 2, 3, 0};
-
-    //     rectModel.UpdateMesh(
-    //         {
-    //             sizeof(glm::vec3),
-    //             rects.Data(),
-    //             static_cast<u32>(rects.Count()),
-    //             indices,
-    //             5
-    //         }
-    //     );
-
-    //     rectModel.Bind(commandBuffer);
-    //     rectModel.Draw(commandBuffer, 0);
-    // }
-
     void Renderer3D::RecreateMaterials()
     {
         if (currentMaterial) currentMaterial->RecreatePipeline(); 
+        debugRenderer.RecreateMaterials();
+        billboardRenderer.RecreateMaterials();
+        gridMaterial.RecreatePipeline();
     }
 
     void Renderer3D::Flush()

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -19,8 +19,6 @@ namespace SnekVk
 
     Material Renderer3D::gridMaterial;
 
-    bool Renderer3D::gridEnabled = false;
-
     DebugRenderer3D Renderer3D::debugRenderer;
     BillboardRenderer Renderer3D::billboardRenderer;
 
@@ -145,11 +143,6 @@ namespace SnekVk
         gridMaterial.Bind(commandBuffer);
 
         vkCmdDraw(commandBuffer, 6, 1, 0, 0);
-    }
-
-    void Renderer3D::EnableGrid()
-    {
-        gridEnabled = true;
     }
 
     void Renderer3D::RecreateMaterials()

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -239,23 +239,12 @@ namespace SnekVk
             (gridData.columns / 2.0) - (gridData.gridScale.y * 0.5f), 
             0.f
         });
-        
-        AddWireQuad(
-        {
-            gridData.nextTopRightIndex, 
-            gridData.nextBottomRightIndex,
-            gridData.nextBottomRightIndex,
-        }, 3);
 
-        for(size_t i = 2; i < gridData.rows; i++)
-        {
-            bool isEven = i % 2 == 0;
+        DrawFirstRow();
 
-            AddWireQuad({
-                isEven ? gridData.nextBottomRightIndex : gridData.nextTopRightIndex,
-                isEven ? gridData.nextTopRightIndex : gridData.nextBottomRightIndex,
-                isEven ? gridData.nextTopRightIndex : gridData.nextBottomRightIndex
-            }, 2);
+        for (size_t i = 1; i < gridData.columns; i++)
+        {
+            DrawRow(i);
         }
 
         rectModel.UpdateMesh(
@@ -299,8 +288,75 @@ namespace SnekVk
     }
 
     void Renderer3D::DrawFirstRow()
-    {
+    {   
+        AddWireQuad(
+        {
+            gridData.nextTopRightIndex, 
+            gridData.nextBottomRightIndex,
+            gridData.nextBottomRightIndex,
+        }, 3);
 
+        for(size_t i = 2; i < gridData.rows; i++)
+        {
+            bool isEven = i % 2 == 0;
+
+            AddWireQuad({
+                isEven ? gridData.nextBottomRightIndex : gridData.nextTopRightIndex,
+                isEven ? gridData.nextTopRightIndex : gridData.nextBottomRightIndex,
+                isEven ? gridData.nextTopRightIndex : gridData.nextBottomRightIndex
+            }, 2);
+        }
+
+        // Reset to first quad for this row.
+        gridData.nextTopRightIndex = 1;
+        gridData.nextBottomRightIndex = 2;
+        gridData.nextBottomLeftIndex = 3;
+        gridData.nextTopLeftIndex = 0;
+    }
+
+    // TODO(Aryeh): Automate this so that we can put in n number of quads
+    void Renderer3D::DrawRow(size_t row)
+    {
+        u32 start = 0;
+
+        start = gridData.rows % 2 == 0 ? gridData.nextBottomLeftIndex : gridData.nextTopLeftIndex;
+
+        gridData.indices[gridData.indexCount++] = start;
+        gridData.indices[gridData.indexCount++] = (gridData.rows * 2) + 2;
+        gridData.indices[gridData.indexCount++] = (gridData.rows * 2) + 3;
+        gridData.indices[gridData.indexCount++] = gridData.nextBottomRightIndex;
+
+        glm::vec3 bottomLeftVertexPosition = gridData.vertices[gridData.nextBottomLeftIndex];
+        glm::vec3 bottomRightVertexPosition = gridData.vertices[gridData.nextBottomRightIndex];
+
+        bottomLeftVertexPosition.y += gridData.gridScale.y;
+        bottomRightVertexPosition.y += gridData.gridScale.y;
+
+        gridData.vertices[gridData.vertexCount++] = bottomLeftVertexPosition;
+        gridData.vertices[gridData.vertexCount++] = bottomRightVertexPosition;
+
+        // Next Quad
+        gridData.nextTopRightIndex = gridData.nextBottomRightIndex + 3;
+        gridData.nextBottomRightIndex = (gridData.rows * 2) + 4;
+        gridData.nextBottomLeftIndex = (gridData.rows * 2) + 3;
+
+        gridData.indices[gridData.indexCount++] = gridData.nextTopRightIndex;
+        gridData.indices[gridData.indexCount++] = gridData.nextBottomRightIndex;
+        gridData.indices[gridData.indexCount++] = gridData.nextBottomLeftIndex;
+
+        bottomRightVertexPosition.x += gridData.gridScale.x;
+        gridData.vertices[gridData.vertexCount++] = bottomRightVertexPosition;
+
+        // Next Quad
+        gridData.nextTopRightIndex = gridData.nextTopRightIndex + 2;
+        gridData.nextBottomRightIndex += 1;
+        gridData.nextBottomLeftIndex += 1;
+
+        gridData.indices[gridData.indexCount++] = gridData.nextBottomRightIndex;
+        gridData.indices[gridData.indexCount++] = gridData.nextTopRightIndex;
+
+        bottomRightVertexPosition.x += gridData.gridScale.x;
+        gridData.vertices[gridData.vertexCount++] = bottomRightVertexPosition;
     }
 
     void Renderer3D::AddWireQuad(std::initializer_list<u32> indices, const u32 indexModifier)

--- a/src/Renderer/Renderers/Renderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D.cpp
@@ -22,6 +22,7 @@ namespace SnekVk
     bool Renderer3D::gridEnabled = false;
 
     DebugRenderer3D Renderer3D::debugRenderer;
+    BillboardRenderer Renderer3D::billboardRenderer;
 
     void Renderer3D::Initialise()
     {
@@ -29,6 +30,7 @@ namespace SnekVk
         globalDataId = INTERN_STR("globalData");
 
         debugRenderer.Initialise("globalData", sizeof(GlobalData));
+        billboardRenderer.Initialise("globalData", sizeof(GlobalData));
         
         auto gridShader = SnekVk::Shader::BuildShader()
             .FromShader("shaders/grid.vert.spv")
@@ -51,6 +53,11 @@ namespace SnekVk
         auto transform = Utils::Math::CalculateTransform3D(position, rotation, scale);
         auto normal = Utils::Math::CalculateNormalMatrix(rotation, scale);
         transforms.Append({transform, normal});
+    }
+
+    void Renderer3D::DrawBillboard(const glm::vec3& position, const glm::vec2& scale, const glm::vec4& colour)
+    {
+        billboardRenderer.DrawBillboard(position, scale, colour);
     }
 
     void Renderer3D::DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale)
@@ -78,6 +85,7 @@ namespace SnekVk
         RenderLights(commandBuffer, globalData);
 
         debugRenderer.Render(commandBuffer, globalDataSize, &globalData);
+        billboardRenderer.Render(commandBuffer, globalDataSize, &globalData);
         
         if (gridEnabled) RenderGrid(commandBuffer, globalData);
 
@@ -183,6 +191,7 @@ namespace SnekVk
     void Renderer3D::Flush()
     {
         debugRenderer.Flush();
+        billboardRenderer.Flush();
         transforms.Clear();
         models.Clear();
     }
@@ -190,6 +199,7 @@ namespace SnekVk
     void Renderer3D::DestroyRenderer3D()
     {
         debugRenderer.Destroy();
+        billboardRenderer.Destroy();
         gridMaterial.DestroyMaterial();
     }
 }

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -78,7 +78,7 @@ namespace SnekVk
         static void RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         
         static void DrawFirstGridQuad(const glm::vec3& offset); 
-        static void DrawWireQuad(const u32 baseIndex);
+        static void AddWireQuad(std::initializer_list<u32> indices, const u32 indexModifier);
         static void DrawFirstRow();
         
         static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -7,6 +7,7 @@
 #include "../Lights/PointLight.h"
 #include "../Camera/Camera.h"
 #include "Renderer3D/DebugRenderer3D.h"
+#include "Renderer3D/BillboardRenderer.h"
 
 namespace SnekVk
 {
@@ -26,7 +27,7 @@ namespace SnekVk
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale);
         static void DrawModel(Model* model, const glm::vec3& position);
 
-        static void DrawBillboard(Model* model, const glm::vec3& position, const glm::vec2& scale, const float& rotation);
+        static void DrawBillboard(const glm::vec3& position, const glm::vec2& scale, const glm::vec4& colour);
 
         // Debug rendering
         // TODO(Aryeh): Move this to it's own renderer module?
@@ -68,6 +69,7 @@ namespace SnekVk
         // FIXME(Aryeh): Everything below this needs to change.
 
         static DebugRenderer3D debugRenderer;
+        static BillboardRenderer billboardRenderer;
 
         // Lights need to exist in their own collection.
         static Model* lightModel;

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -82,6 +82,7 @@ namespace SnekVk
         static void RenderLines(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
+        static void RenderGridGPU(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         
         static void DrawFirstGridQuad(const glm::vec3& offset); 
         static void AddWireQuad(std::initializer_list<u32> indices, std::initializer_list<glm::vec3> vertices, const QuadIndexExtents& extentIndices, const glm::vec3& scale);
@@ -115,6 +116,9 @@ namespace SnekVk
 
         static Material rectMaterial;
         static Model rectModel;
+
+        static Material gridMaterial;
+        static Model gridModel;
 
         static Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> lines;
         static Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> rects;

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -36,8 +36,6 @@ namespace SnekVk
 
         static void DrawLight(Model* model);
 
-        static void EnableGrid();
-
         static void RecreateMaterials();
 
         static void Render(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
@@ -75,7 +73,5 @@ namespace SnekVk
         static Model* lightModel;
 
         static Material gridMaterial;
-
-        static bool gridEnabled;
     };
 }

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -24,6 +24,14 @@ namespace SnekVk
             glm::vec3 color{1.f, 1.f, 1.f};
         };
 
+        struct QuadIndexExtents
+        {
+            u32 topLeft;
+            u32 topRight;
+            u32 bottomRight;
+            u32 bottomLeft;
+        };
+
         static void Initialise();
 
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation);
@@ -79,7 +87,7 @@ namespace SnekVk
         static void RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         
         static void DrawFirstGridQuad(const glm::vec3& offset); 
-        static void AddWireQuad(std::initializer_list<u32> indices, const u32 indexModifier);
+        static void AddWireQuad(std::initializer_list<u32> indices, std::initializer_list<glm::vec3> vertices, const QuadIndexExtents& extentIndices, const glm::vec3& scale);
         static void DrawFirstRow();
         static void DrawRow(size_t row);
         

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -31,7 +31,11 @@ namespace SnekVk
         static void DrawModel(Model* model, const glm::vec3& position);
 
         static void DrawBillboard(Model* model, const glm::vec3& position, const glm::vec2& scale, const float& rotation);
+
+        // Debug rendering
+        // TODO(Aryeh): Move this to it's own renderer module?
         static void DrawLine(const glm::vec3& origin, const glm::vec3& destination, glm::vec3 color);
+        static void DrawRect(const glm::vec3& position, const glm::vec2& scale, glm::vec3 color);
 
         static void DrawLight(Model* model);
 
@@ -47,6 +51,7 @@ namespace SnekVk
         static void RenderModels(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLights(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLines(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
+        static void RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         
         static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
 
@@ -73,6 +78,10 @@ namespace SnekVk
         // This should exist possibly in an array of other debug lines.
         static LineData lineData;
 
+        static Material rectMaterial;
+        static Model rectModel;
+
         static Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> lines;
+        static Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> rects;
     };
 }

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -37,7 +37,7 @@ namespace SnekVk
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation);
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale);
         static void DrawModel(Model* model, const glm::vec3& position);
-        static void DrawGrid(size_t rowCount, size_t columnCount, glm::vec2 scale);
+        static void DrawGrid(size_t rowCount, size_t columnCount, glm::vec3 scale);
 
         static void DrawBillboard(Model* model, const glm::vec3& position, const glm::vec2& scale, const float& rotation);
 
@@ -58,16 +58,13 @@ namespace SnekVk
         private:
 
         static struct GridData{
-            glm::vec3 rotation{0.f, 0.f, 0.f};
-            glm::vec2 gridScale{1.f, 1.f};
+            glm::vec3 gridScale{1.f, 1.f, 1.f};
 
             glm::vec3 vertices[Mesh::MAX_VERTICES];
             u32 indices[Mesh::MAX_INDICES];
 
             u32 indexCount = 0;
             u32 vertexCount = 0;
-
-            u32 latestIndex = 0; 
 
             u32 nextTopRightIndex = 0;
             u32 nextBottomRightIndex = 0;
@@ -89,7 +86,7 @@ namespace SnekVk
         static void DrawFirstGridQuad(const glm::vec3& offset); 
         static void AddWireQuad(std::initializer_list<u32> indices, std::initializer_list<glm::vec3> vertices, const QuadIndexExtents& extentIndices, const glm::vec3& scale);
         static void DrawFirstRow();
-        static void DrawRow(size_t row);
+        static void DrawRow(u32 row);
         
         static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
 

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -6,6 +6,7 @@
 #include "../Utils/Math.h"
 #include "../Lights/PointLight.h"
 #include "../Camera/Camera.h"
+#include "Renderer3D/DebugRenderer3D.h"
 
 namespace SnekVk
 {
@@ -19,11 +20,6 @@ namespace SnekVk
             PointLight::Data lightData;
         };
 
-        struct LineData
-        {
-            glm::vec3 color{1.f, 1.f, 1.f};
-        };
-
         static void Initialise();
 
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation);
@@ -34,7 +30,7 @@ namespace SnekVk
 
         // Debug rendering
         // TODO(Aryeh): Move this to it's own renderer module?
-        static void DrawLine(const glm::vec3& origin, const glm::vec3& destination, glm::vec3 color);
+        static void DrawLine(const glm::vec3& origin, const glm::vec3& destination, const glm::vec3& colour);
         static void DrawRect(const glm::vec3& position, const glm::vec2& scale, glm::vec3 color);
 
         static void DrawLight(Model* model);
@@ -53,7 +49,7 @@ namespace SnekVk
         static void RenderModels(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLights(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLines(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
-        static void RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
+        //static void RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         
         static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
@@ -71,24 +67,13 @@ namespace SnekVk
 
         // FIXME(Aryeh): Everything below this needs to change.
 
+        static DebugRenderer3D debugRenderer;
+
         // Lights need to exist in their own collection.
         static Model* lightModel;
-
-        // Lines need to exist in their own collection as well.
-        static Material lineMaterial;
-        static Model lineModel;
-
-        // This should exist possibly in an array of other debug lines.
-        static LineData lineData;
-
-        static Material rectMaterial;
-        static Model rectModel;
 
         static Material gridMaterial;
 
         static bool gridEnabled;
-
-        static Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> lines;
-        static Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> rects;
     };
 }

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -52,6 +52,7 @@ namespace SnekVk
         static void RenderLights(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLines(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
+        static void RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         
         static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
 

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -37,7 +37,6 @@ namespace SnekVk
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation);
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale);
         static void DrawModel(Model* model, const glm::vec3& position);
-        static void DrawGrid(size_t rowCount, size_t columnCount, glm::vec3 scale);
 
         static void DrawBillboard(Model* model, const glm::vec3& position, const glm::vec2& scale, const float& rotation);
 
@@ -48,6 +47,8 @@ namespace SnekVk
 
         static void DrawLight(Model* model);
 
+        static void EnableGrid();
+
         static void RecreateMaterials();
 
         static void Render(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
@@ -57,37 +58,11 @@ namespace SnekVk
 
         private:
 
-        static struct GridData{
-            glm::vec3 gridScale{1.f, 1.f, 1.f};
-
-            glm::vec3 vertices[Mesh::MAX_VERTICES];
-            u32 indices[Mesh::MAX_INDICES];
-
-            u32 indexCount = 0;
-            u32 vertexCount = 0;
-
-            u32 nextTopRightIndex = 0;
-            u32 nextBottomRightIndex = 0;
-            u32 nextBottomLeftIndex = 0;
-            u32 nextTopLeftIndex = 0;
-
-            u32 rows = 0; 
-            u32 columns = 0;
-
-            bool enabled = false;
-        } gridData;
-
         static void RenderModels(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLights(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLines(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
-        static void RenderGridGPU(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
-        
-        static void DrawFirstGridQuad(const glm::vec3& offset); 
-        static void AddWireQuad(std::initializer_list<u32> indices, std::initializer_list<glm::vec3> vertices, const QuadIndexExtents& extentIndices, const glm::vec3& scale);
-        static void DrawFirstRow();
-        static void DrawRow(u32 row);
         
         static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
 
@@ -118,7 +93,8 @@ namespace SnekVk
         static Model rectModel;
 
         static Material gridMaterial;
-        static Model gridModel;
+
+        static bool gridEnabled;
 
         static Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> lines;
         static Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> rects;

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -9,6 +9,7 @@
 #include "Renderer3D/DebugRenderer3D.h"
 #include "Renderer3D/BillboardRenderer.h"
 #include "Renderer3D/LightRenderer.h"
+#include "Renderer3D/ModelRenderer.h"
 
 namespace SnekVk
 {
@@ -34,8 +35,7 @@ namespace SnekVk
         // TODO(Aryeh): Move this to it's own renderer module?
         static void DrawLine(const glm::vec3& origin, const glm::vec3& destination, const glm::vec3& colour);
         static void DrawRect(const glm::vec3& position, const glm::vec2& scale, glm::vec3 color);
-
-        static void DrawLight(const glm::vec3& position, const float& radius, const glm::vec4& colour, const glm::vec4& ambientColor);
+        static void DrawPointLight(const glm::vec3& position, const float& radius, const glm::vec4& colour, const glm::vec4& ambientColor);
 
         static void RecreateMaterials();
 
@@ -45,34 +45,18 @@ namespace SnekVk
         static void DestroyRenderer3D();
 
         private:
-
-        static void RenderModels(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
-        static void RenderLights(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
-        static void RenderLines(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
+        
         //static void RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
-        
-        static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
 
-        static Utils::StackArray<Model::Transform, MAX_OBJECT_TRANSFORMS> transforms;
-        static Utils::StackArray<Model*, MAX_OBJECT_TRANSFORMS> models;
-
-        static u64 transformSize;
-
-        static Utils::StringId transformId;
         static Utils::StringId globalDataId;
-
-        static Material* currentMaterial; 
-        static Model* currentModel;
 
         // FIXME(Aryeh): Everything below this needs to change.
 
+        static ModelRenderer modelRenderer;
         static DebugRenderer3D debugRenderer;
         static BillboardRenderer billboardRenderer;
         static LightRenderer lightRenderer;
-
-        // Lights need to exist in their own collection.
-        static Model* lightModel;
 
         static Material gridMaterial;
 

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -8,6 +8,7 @@
 #include "../Camera/Camera.h"
 #include "Renderer3D/DebugRenderer3D.h"
 #include "Renderer3D/BillboardRenderer.h"
+#include "Renderer3D/LightRenderer.h"
 
 namespace SnekVk
 {
@@ -34,11 +35,11 @@ namespace SnekVk
         static void DrawLine(const glm::vec3& origin, const glm::vec3& destination, const glm::vec3& colour);
         static void DrawRect(const glm::vec3& position, const glm::vec2& scale, glm::vec3 color);
 
-        static void DrawLight(Model* model);
+        static void DrawLight(const glm::vec3& position, const float& radius, const glm::vec4& colour, const glm::vec4& ambientColor);
 
         static void RecreateMaterials();
 
-        static void Render(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
+        static void Render(VkCommandBuffer& commandBuffer, const CameraData& globalData);
         static void Flush();
 
         static void DestroyRenderer3D();
@@ -68,10 +69,13 @@ namespace SnekVk
 
         static DebugRenderer3D debugRenderer;
         static BillboardRenderer billboardRenderer;
+        static LightRenderer lightRenderer;
 
         // Lights need to exist in their own collection.
         static Model* lightModel;
 
         static Material gridMaterial;
+
+        static GlobalData global3DData;
     };
 }

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -29,6 +29,7 @@ namespace SnekVk
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation);
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale);
         static void DrawModel(Model* model, const glm::vec3& position);
+        static void DrawGrid(size_t rowCount, size_t columnCount, glm::vec2 scale);
 
         static void DrawBillboard(Model* model, const glm::vec3& position, const glm::vec2& scale, const float& rotation);
 
@@ -48,11 +49,37 @@ namespace SnekVk
 
         private:
 
+        static struct GridData{
+            glm::vec3 rotation{0.f, 0.f, 0.f};
+            glm::vec2 gridScale{1.f, 1.f};
+
+            glm::vec3 vertices[Mesh::MAX_VERTICES];
+            u32 indices[Mesh::MAX_INDICES];
+
+            u32 indexCount = 0;
+            u32 vertexCount = 0;
+
+            u32 latestIndex = 0; 
+
+            u32 nextTopRightIndex = 0;
+            u32 nextBottomRightIndex = 0;
+            u32 nextBottomLeftIndex = 0;
+
+            u32 rows = 0; 
+            u32 columns = 0;
+
+            bool enabled = false;
+        } gridData;
+
         static void RenderModels(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLights(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderLines(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderRects(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
         static void RenderGrid(VkCommandBuffer& commandBuffer, const GlobalData& globalData);
+        
+        static void DrawFirstGridQuad(const glm::vec3& offset); 
+        static void DrawWireQuad(const u32 baseIndex);
+        static void DrawFirstRow();
         
         static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
 

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -24,14 +24,6 @@ namespace SnekVk
             glm::vec3 color{1.f, 1.f, 1.f};
         };
 
-        struct QuadIndexExtents
-        {
-            u32 topLeft;
-            u32 topRight;
-            u32 bottomRight;
-            u32 bottomLeft;
-        };
-
         static void Initialise();
 
         static void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation);

--- a/src/Renderer/Renderers/Renderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D.h
@@ -64,6 +64,7 @@ namespace SnekVk
             u32 nextTopRightIndex = 0;
             u32 nextBottomRightIndex = 0;
             u32 nextBottomLeftIndex = 0;
+            u32 nextTopLeftIndex = 0;
 
             u32 rows = 0; 
             u32 columns = 0;
@@ -80,6 +81,7 @@ namespace SnekVk
         static void DrawFirstGridQuad(const glm::vec3& offset); 
         static void AddWireQuad(std::initializer_list<u32> indices, const u32 indexModifier);
         static void DrawFirstRow();
+        static void DrawRow(size_t row);
         
         static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
 

--- a/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
@@ -11,7 +11,7 @@ namespace SnekVk
         positionsId = INTERN_STR("positions");
 
         auto vertexShader = Shader::BuildShader()
-            .FromShader("bin/shaders/billboard.vert.spv")
+            .FromShader("shaders/billboard.vert.spv")
             .WithStage(PipelineConfig::VERTEX)
             .WithVertexType(sizeof(BillboardVertex))
             .WithVertexAttribute(offsetof(BillboardVertex, position), SnekVk::VertexDescription::VEC3)
@@ -20,7 +20,7 @@ namespace SnekVk
             .WithStorage(1, "positions", sizeof(glm::vec3), 1000);
         
         auto fragmentShader = Shader::BuildShader()
-            .FromShader("bin/shaders/billboard.frag.spv")
+            .FromShader("shaders/billboard.frag.spv")
             .WithStage(PipelineConfig::FRAGMENT);
         
         billboardMaterial.SetVertexShader(&vertexShader);

--- a/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
@@ -1,0 +1,92 @@
+#include "BillboardRenderer.h"
+
+namespace SnekVk
+{
+    BillboardRenderer::BillboardRenderer() {}
+    BillboardRenderer::~BillboardRenderer() {}
+
+    void BillboardRenderer::Initialise(const char* globalDataAttributeName, const u64& globalDataSize)
+    {
+        globalDataId = INTERN_STR(globalDataAttributeName);
+        positionsId = INTERN_STR("positions");
+
+        auto vertexShader = Shader::BuildShader()
+            .FromShader("bin/shaders/billboard.vert.spv")
+            .WithStage(PipelineConfig::VERTEX)
+            .WithVertexType(sizeof(BillboardVertex))
+            .WithVertexAttribute(offsetof(BillboardVertex, position), SnekVk::VertexDescription::VEC3)
+            .WithVertexAttribute(offsetof(BillboardVertex, colour), SnekVk::VertexDescription::VEC4)
+            .WithUniform(0, globalDataAttributeName, globalDataSize)
+            .WithStorage(1, "positions", sizeof(glm::vec3), 1000);
+        
+        auto fragmentShader = Shader::BuildShader()
+            .FromShader("bin/shaders/billboard.frag.spv")
+            .WithStage(PipelineConfig::FRAGMENT);
+        
+        billboardMaterial.SetVertexShader(&vertexShader);
+        billboardMaterial.SetFragmentShader(&fragmentShader);
+        billboardMaterial.BuildMaterial();
+
+        billboardModel.SetMesh({
+            sizeof(BillboardVertex),
+            nullptr,
+            0,
+            nullptr,
+            0
+        });
+
+        billboardModel.SetMaterial(&billboardMaterial);
+    }
+
+    void BillboardRenderer::Destroy()
+    {
+        billboardMaterial.DestroyMaterial();
+        billboardModel.DestroyModel();
+    }
+
+    void BillboardRenderer::DrawBillboard(const glm::vec3& position, const glm::vec2& scale, const glm::vec4& colour) 
+    {
+        vertices.Append({{position.x + (scale.x * 0.5), position.y + (scale.y * 0.5), position.z}, colour});
+        vertices.Append({{position.x + (scale.x * 0.5), position.y - (scale.y * 0.5), position.z}, colour});
+        vertices.Append({{position.x - (scale.x * 0.5), position.y - (scale.y * 0.5), position.z}, colour});
+        vertices.Append({{position.x - (scale.x * 0.5), position.y + (scale.y * 0.5), position.z}, colour});
+
+        // Pattern: 0, 1, 3, 1, 2, 3
+        indices.Append(vertices.Count()-4);
+        indices.Append(vertices.Count()-3);
+        indices.Append(vertices.Count()-1);
+
+        indices.Append(vertices.Count()-3);
+        indices.Append(vertices.Count()-2);
+        indices.Append(vertices.Count()-1);
+
+        positions.Append(position);
+    }
+
+    void BillboardRenderer::Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData)
+    {
+        if (vertices.Count() == 0) return;
+
+        billboardMaterial.SetUniformData(globalDataId, globalDataSize, globalData);
+        billboardMaterial.SetUniformData(positionsId, sizeof(positions[0]) * positions.Count(), positions.Data());
+        billboardMaterial.Bind(commandBuffer);
+
+        billboardModel.UpdateMesh({
+            sizeof(BillboardVertex),
+            vertices.Data(),
+            static_cast<u32>(vertices.Count()),
+            indices.Data(),
+            static_cast<u32>(indices.Count())
+        });
+
+        billboardModel.Bind(commandBuffer);
+        billboardModel.Draw(commandBuffer);
+    }
+
+    void BillboardRenderer::Flush()
+    {
+        vertices.Clear();
+        indices.Clear();
+        positions.Clear();
+    }
+}

--- a/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
@@ -38,6 +38,11 @@ namespace SnekVk
         billboardModel.SetMaterial(&billboardMaterial);
     }
 
+    void BillboardRenderer::RecreateMaterials()
+    {
+        billboardMaterial.RecreatePipeline();
+    };
+
     void BillboardRenderer::Destroy()
     {
         billboardMaterial.DestroyMaterial();

--- a/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
@@ -17,7 +17,7 @@ namespace SnekVk
             .WithVertexAttribute(offsetof(BillboardVertex, position), SnekVk::VertexDescription::VEC3)
             .WithVertexAttribute(offsetof(BillboardVertex, colour), SnekVk::VertexDescription::VEC4)
             .WithUniform(0, globalDataAttributeName, globalDataSize)
-            .WithStorage(1, "positions", sizeof(glm::vec3), 1000);
+            .WithStorage(1, "positions", sizeof(BillboardUBO), 1000);
         
         auto fragmentShader = Shader::BuildShader()
             .FromShader("shaders/billboard.frag.spv")
@@ -46,10 +46,10 @@ namespace SnekVk
 
     void BillboardRenderer::DrawBillboard(const glm::vec3& position, const glm::vec2& scale, const glm::vec4& colour) 
     {
-        vertices.Append({{position.x + (scale.x * 0.5), position.y + (scale.y * 0.5), position.z}, colour});
-        vertices.Append({{position.x + (scale.x * 0.5), position.y - (scale.y * 0.5), position.z}, colour});
-        vertices.Append({{position.x - (scale.x * 0.5), position.y - (scale.y * 0.5), position.z}, colour});
-        vertices.Append({{position.x - (scale.x * 0.5), position.y + (scale.y * 0.5), position.z}, colour});
+        vertices.Append({{1.f, 1.f, 1.f}, colour});
+        vertices.Append({{1.f, -1.f, 1.f}, colour});
+        vertices.Append({{-1.f, -1.f, 1.f}, colour});
+        vertices.Append({{-1.f, 1.f, 1.f}, colour});
 
         // Pattern: 0, 1, 3, 1, 2, 3
         indices.Append(vertices.Count()-4);
@@ -60,7 +60,7 @@ namespace SnekVk
         indices.Append(vertices.Count()-2);
         indices.Append(vertices.Count()-1);
 
-        positions.Append(position);
+        positions.Append({position, glm::vec3(scale, 0.f)});
     }
 
     void BillboardRenderer::Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData)
@@ -68,7 +68,7 @@ namespace SnekVk
         if (vertices.Count() == 0) return;
 
         billboardMaterial.SetUniformData(globalDataId, globalDataSize, globalData);
-        billboardMaterial.SetUniformData(positionsId, sizeof(positions[0]) * positions.Count(), positions.Data());
+        billboardMaterial.SetUniformData(positionsId, sizeof(positions[0]) * positions.Size(), positions.Data());
         billboardMaterial.Bind(commandBuffer);
 
         billboardModel.UpdateMesh({

--- a/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/BillboardRenderer.cpp
@@ -73,7 +73,7 @@ namespace SnekVk
         if (vertices.Count() == 0) return;
 
         billboardMaterial.SetUniformData(globalDataId, globalDataSize, globalData);
-        billboardMaterial.SetUniformData(positionsId, sizeof(positions[0]) * positions.Size(), positions.Data());
+        billboardMaterial.SetUniformData(positionsId, sizeof(positions[0]) * positions.Count(), positions.Data());
         billboardMaterial.Bind(commandBuffer);
 
         billboardModel.UpdateMesh({

--- a/src/Renderer/Renderers/Renderer3D/BillboardRenderer.h
+++ b/src/Renderer/Renderers/Renderer3D/BillboardRenderer.h
@@ -22,12 +22,14 @@ namespace SnekVk
 
         void Flush();
 
+        void RecreateMaterials();
+
         private:
 
         struct BillboardVertex 
         {
             glm::vec3 position;
-            alignas(16) glm::vec4 colour;
+            glm::vec4 colour;
         };
 
         struct BillboardUBO

--- a/src/Renderer/Renderers/Renderer3D/BillboardRenderer.h
+++ b/src/Renderer/Renderers/Renderer3D/BillboardRenderer.h
@@ -30,6 +30,12 @@ namespace SnekVk
             alignas(16) glm::vec4 colour;
         };
 
+        struct BillboardUBO
+        {
+            alignas(16) glm::vec3 position;
+            alignas(16) glm::vec3 scale;
+        };
+
         u32 billboardCount;
 
         Material billboardMaterial;
@@ -40,6 +46,6 @@ namespace SnekVk
 
         Utils::StackArray<BillboardVertex, Mesh::MAX_VERTICES> vertices;
         Utils::StackArray<u32, Mesh::MAX_INDICES> indices;
-        Utils::StackArray<glm::vec3, 1000> positions;
+        Utils::StackArray<BillboardUBO, 1000> positions;
     };
 }

--- a/src/Renderer/Renderers/Renderer3D/BillboardRenderer.h
+++ b/src/Renderer/Renderers/Renderer3D/BillboardRenderer.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "../../Core.h"
+#include "../../Material/Material.h"
+#include "../../Model/Model.h"
+
+namespace SnekVk
+{
+    class BillboardRenderer
+    {
+        public:
+
+        BillboardRenderer();
+        ~BillboardRenderer();
+
+        void Initialise(const char* globalDataAttributeName, const u64& globalDataSize);
+        void Destroy();
+
+        void DrawBillboard(const glm::vec3& position, const glm::vec2& scale, const glm::vec4& colour);
+
+        void Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData);
+
+        void Flush();
+
+        private:
+
+        struct BillboardVertex 
+        {
+            glm::vec3 position;
+            alignas(16) glm::vec4 colour;
+        };
+
+        u32 billboardCount;
+
+        Material billboardMaterial;
+        Model billboardModel;
+
+        Utils::StringId globalDataId;
+        Utils::StringId positionsId;
+
+        Utils::StackArray<BillboardVertex, Mesh::MAX_VERTICES> vertices;
+        Utils::StackArray<u32, Mesh::MAX_INDICES> indices;
+        Utils::StackArray<glm::vec3, 1000> positions;
+    };
+}

--- a/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.cpp
@@ -1,0 +1,94 @@
+#include "DebugRenderer3D.h"
+
+namespace SnekVk
+{
+    DebugRenderer3D::DebugRenderer3D() {}
+    
+    DebugRenderer3D::~DebugRenderer3D() {}
+
+    void DebugRenderer3D::Initialise(const char* globalDataAttributeName, const u64& globalDataSize)
+    {
+        globalDataId = INTERN_STR(globalDataAttributeName);
+        
+        // vertex Shaders
+        auto vertexShader = Shader::BuildShader()
+            .FromShader("shaders/line.vert.spv")
+            .WithStage(PipelineConfig::VERTEX)
+            .WithVertexType(sizeof(LineVertex))
+            .WithVertexAttribute(offsetof(LineVertex, position), SnekVk::VertexDescription::VEC3)
+            .WithVertexAttribute(offsetof(LineVertex, colour), SnekVk::VertexDescription::VEC3)
+            .WithUniform(0, globalDataAttributeName, globalDataSize, 1);
+        
+        // fragmentShaders
+        auto fragmentShader = Shader::BuildShader()
+            .FromShader("shaders/line.frag.spv")
+            .WithStage(PipelineConfig::FRAGMENT);
+        
+        lineMaterial.SetVertexShader(&vertexShader);
+        lineMaterial.SetFragmentShader(&fragmentShader);
+        lineMaterial.SetTopology(Material::Topology::LINE_LIST);
+        lineMaterial.BuildMaterial();
+
+        // Set empty mesh
+        lineModel.SetMesh({
+            sizeof(LineVertex),
+            nullptr,
+            0,
+            nullptr,
+            0
+        });
+
+        lineModel.SetMaterial(&lineMaterial);
+    }
+
+    void DebugRenderer3D::Destroy()
+    {
+        lineMaterial.DestroyMaterial();
+        lineModel.DestroyModel();
+        rectMaterial.DestroyMaterial();
+        rectModel.DestroyModel();
+    }
+
+    // Wire primitives
+    void DebugRenderer3D::DrawLine(const glm::vec3& origin, const glm::vec3& destination, const glm::vec3& colour)
+    {
+        lines.Append({origin, colour});
+        lines.Append({destination, colour});
+    }
+
+    void DebugRenderer3D::DrawCube()
+    {
+
+    }
+
+    void DebugRenderer3D::Flush()
+    {
+        lines.Clear();
+    }
+
+    void DebugRenderer3D::RenderLines(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData)
+    {
+        if (lines.Count() == 0) return;
+
+        lineMaterial.SetUniformData(globalDataId, globalDataSize, globalData);
+        lineMaterial.Bind(commandBuffer);
+
+        lineModel.UpdateMesh(
+            {
+                sizeof(LineVertex),
+                lines.Data(),
+                static_cast<u32>(lines.Count()),
+                nullptr,
+                0
+            }
+        );
+
+        lineModel.Bind(commandBuffer);
+        lineModel.Draw(commandBuffer, 0);
+    }
+
+    void DebugRenderer3D::Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData)
+    {
+        RenderLines(commandBuffer, globalDataSize, globalData);
+    }
+}

--- a/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.cpp
@@ -56,7 +56,7 @@ namespace SnekVk
         lines.Append({destination, colour});
     }
 
-    void DebugRenderer3D::DrawCube()
+    void DebugRenderer3D::DrawCube(const glm::vec3& position, const glm::vec3& rotation, const glm::vec3& scale)
     {
 
     }

--- a/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.cpp
+++ b/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.cpp
@@ -49,6 +49,12 @@ namespace SnekVk
         rectModel.DestroyModel();
     }
 
+    void DebugRenderer3D::RecreateMaterials()
+    {
+        lineMaterial.RecreatePipeline();
+        rectMaterial.RecreatePipeline();
+    }
+
     // Wire primitives
     void DebugRenderer3D::DrawLine(const glm::vec3& origin, const glm::vec3& destination, const glm::vec3& colour)
     {

--- a/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.h
@@ -24,6 +24,8 @@ namespace SnekVk
 
         void Flush();
 
+        void RecreateMaterials();
+
         private: 
 
         struct LineVertex

--- a/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.h
@@ -18,7 +18,7 @@ namespace SnekVk
 
         // Wire primitives
         void DrawLine(const glm::vec3& origin, const glm::vec3& destination, const glm::vec3& colour);
-        void DrawCube();
+        void DrawCube(const glm::vec3& position, const glm::vec3& rotation, const glm::vec3& scale);
 
         void Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData);
 

--- a/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.h
+++ b/src/Renderer/Renderers/Renderer3D/DebugRenderer3D.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "../../Core.h"
+#include "../../Model/Model.h"
+#include "../../Material/Material.h"
+
+namespace SnekVk
+{
+    class DebugRenderer3D
+    {
+        public: 
+
+        DebugRenderer3D();
+        ~DebugRenderer3D();
+
+        void Initialise(const char* globalDataAttributeName, const u64& globalDataSize);
+        void Destroy();
+
+        // Wire primitives
+        void DrawLine(const glm::vec3& origin, const glm::vec3& destination, const glm::vec3& colour);
+        void DrawCube();
+
+        void Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData);
+
+        void Flush();
+
+        private: 
+
+        struct LineVertex
+        {
+            glm::vec3 position;
+            glm::vec3 colour;
+        };
+
+        void RenderLines(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData);
+        void RenderRects();
+
+        glm::vec3 lineColor;
+
+        Material lineMaterial;
+        Model lineModel;
+
+        Material rectMaterial;
+        Model rectModel;
+
+        Utils::StringId globalDataId;
+
+        Utils::StackArray<LineVertex, Mesh::MAX_VERTICES> lines;
+        Utils::StackArray<glm::vec3, Mesh::MAX_VERTICES> rects;
+    };
+}

--- a/src/Renderer/Renderers/Renderer3D/LightRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/LightRenderer.cpp
@@ -1,0 +1,92 @@
+#include "LightRenderer.h"
+
+namespace SnekVk
+{
+    LightRenderer::LightRenderer() {}
+    LightRenderer::~LightRenderer() {}
+
+    void LightRenderer::Initialise(const char* globalDataAttributeName, const u64& globalDataSize)
+    {
+        globalDataId = INTERN_STR(globalDataAttributeName);
+        lightDataId = INTERN_STR("lightUBO");
+
+        auto pointLightVertShader = SnekVk::Shader::BuildShader()
+            .FromShader("bin/shaders/pointLight.vert.spv")
+            .WithStage(SnekVk::PipelineConfig::VERTEX)
+            .WithVertexType(sizeof(glm::vec2))
+            .WithVertexAttribute(0, SnekVk::VertexDescription::VEC2)
+            .WithUniform(0, globalDataAttributeName, globalDataSize);
+
+        auto pointLightFragShader = SnekVk::Shader::BuildShader()
+            .FromShader("bin/shaders/pointLight.frag.spv")
+            .WithStage(SnekVk::PipelineConfig::FRAGMENT)
+            .WithUniform(0, globalDataAttributeName, globalDataSize);
+        
+        lightMaterial.SetVertexShader(&pointLightVertShader);
+        lightMaterial.SetFragmentShader(&pointLightFragShader);
+        lightMaterial.BuildMaterial();
+
+        lightModel.SetMesh({ 
+            sizeof(glm::vec2),
+            nullptr,
+            0,
+            nullptr,
+            0
+        });
+
+        lightModel.SetMaterial(&lightMaterial);
+    }
+
+    void LightRenderer::Destroy()
+    {
+        lightMaterial.DestroyMaterial();
+        lightModel.DestroyModel();
+    }
+
+    void LightRenderer::DrawPointLight(const glm::vec3& position, const float& radius, const glm::vec4& colour, const glm::vec4& ambientColor)
+    {
+        pointLightVertices.Append({1.f, 1.f});
+        pointLightVertices.Append({1.f, -1.f});
+        pointLightVertices.Append({-1.f, -1.f});
+        pointLightVertices.Append({-1.f, 1.f});
+
+        // Pattern: 0, 1, 3, 1, 2, 3
+        pointLightIndices.Append(pointLightVertices.Count()-4);
+        pointLightIndices.Append(pointLightVertices.Count()-3);
+        pointLightIndices.Append(pointLightVertices.Count()-1);
+
+        pointLightIndices.Append(pointLightVertices.Count()-3);
+        pointLightIndices.Append(pointLightVertices.Count()-2);
+        pointLightIndices.Append(pointLightVertices.Count()-1);
+    }
+
+    void LightRenderer::Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData)
+    {
+        if (pointLightVertices.Count() == 0) return;
+
+        lightMaterial.SetUniformData(globalDataId, sizeof(globalData), globalData);
+        lightMaterial.Bind(commandBuffer);
+
+        lightModel.UpdateMesh({
+            sizeof(glm::vec2),
+            pointLightVertices.Data(),
+            static_cast<u32>(pointLightVertices.Count()),
+            pointLightIndices.Data(),
+            static_cast<u32>(pointLightIndices.Count())
+        });
+
+        lightModel.Bind(commandBuffer);
+        lightModel.Draw(commandBuffer, 0);
+    }
+
+    void LightRenderer::Flush()
+    {
+        pointLightVertices.Clear();
+        pointLightIndices.Clear();
+    }
+
+    void LightRenderer::RecreateMaterials()
+    {
+        lightMaterial.RecreatePipeline();
+    }
+}

--- a/src/Renderer/Renderers/Renderer3D/LightRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/LightRenderer.cpp
@@ -11,14 +11,14 @@ namespace SnekVk
         lightDataId = INTERN_STR("lightUBO");
 
         auto pointLightVertShader = SnekVk::Shader::BuildShader()
-            .FromShader("bin/shaders/pointLight.vert.spv")
+            .FromShader("shaders/pointLight.vert.spv")
             .WithStage(SnekVk::PipelineConfig::VERTEX)
             .WithVertexType(sizeof(glm::vec2))
             .WithVertexAttribute(0, SnekVk::VertexDescription::VEC2)
             .WithUniform(0, globalDataAttributeName, globalDataSize);
 
         auto pointLightFragShader = SnekVk::Shader::BuildShader()
-            .FromShader("bin/shaders/pointLight.frag.spv")
+            .FromShader("shaders/pointLight.frag.spv")
             .WithStage(SnekVk::PipelineConfig::FRAGMENT)
             .WithUniform(0, globalDataAttributeName, globalDataSize);
         

--- a/src/Renderer/Renderers/Renderer3D/LightRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/LightRenderer.cpp
@@ -64,7 +64,7 @@ namespace SnekVk
     {
         if (pointLightVertices.Count() == 0) return;
 
-        lightMaterial.SetUniformData(globalDataId, sizeof(globalData), globalData);
+        lightMaterial.SetUniformData(globalDataId, globalDataSize, globalData);
         lightMaterial.Bind(commandBuffer);
 
         lightModel.UpdateMesh({

--- a/src/Renderer/Renderers/Renderer3D/LightRenderer.h
+++ b/src/Renderer/Renderers/Renderer3D/LightRenderer.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "../../Core.h"
+#include "../../Model/Model.h"
+
+namespace SnekVk
+{
+    class LightRenderer
+    {
+        public:
+
+        LightRenderer();
+        ~LightRenderer();
+
+        void Initialise(const char* globalDataAttributeName, const u64& globalDataSize);
+
+        void Destroy();
+
+        void DrawPointLight(const glm::vec3& position, const float& radius, const glm::vec4& colour, const glm::vec4& ambientColor);
+
+        void Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData);
+
+        void Flush();
+
+        void RecreateMaterials();
+
+        private: 
+
+        struct PointLightVertex
+        {
+            alignas(16) glm::vec2 position;
+        };
+
+        struct LightUBO {
+            glm::vec4 lightColor = glm::vec4(1.f, 1.f, 1.f, 0.2f);
+            alignas(16) glm::vec4 ambientLightColor = glm::vec4(1.f, 1.f, 1.f, .02f);
+            alignas(16) glm::vec3 position = glm::vec3(0.f);
+            alignas(16) float radius = .05f;
+        };
+
+        Model lightModel;
+        Material lightMaterial;
+
+        Utils::StringId globalDataId;
+        Utils::StringId lightDataId;
+
+        Utils::StackArray<glm::vec2, Mesh::MAX_VERTICES> pointLightVertices;
+        Utils::StackArray<u32, Mesh::MAX_INDICES> pointLightIndices;
+    };
+}

--- a/src/Renderer/Renderers/Renderer3D/ModelRenderer.cpp
+++ b/src/Renderer/Renderers/Renderer3D/ModelRenderer.cpp
@@ -1,0 +1,67 @@
+#include "ModelRenderer.h"
+
+namespace SnekVk
+{
+    ModelRenderer::ModelRenderer() {}
+    ModelRenderer::~ModelRenderer() {}
+
+    void ModelRenderer::Initialise(const char* globalDataAttributeName, const u64& globalDataSize) 
+    {
+        globalDataId = INTERN_STR(globalDataAttributeName);
+        transformId = INTERN_STR("objectBuffer");
+    }
+
+    void ModelRenderer::Destroy()
+    {
+
+    }
+
+    void ModelRenderer::DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation)
+    {
+        models.Append(model);
+
+        auto transform = Utils::Math::CalculateTransform3D(position, rotation, scale);
+        auto normal = Utils::Math::CalculateNormalMatrix(rotation, scale);
+        transforms.Append({transform, normal});
+    }
+
+    void ModelRenderer::Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData)
+    {
+        if (models.Count() == 0) return;
+
+        for (size_t i = 0; i < models.Count(); i++)
+        {
+            auto& model = models.Get(i);
+
+            if (currentMaterial != model->GetMaterial())
+            {
+                currentMaterial = model->GetMaterial();
+                currentMaterial->SetUniformData(transformId, sizeof(transforms[0]) * transforms.Count(), transforms.Data());
+                currentMaterial->SetUniformData(globalDataId, globalDataSize, globalData);
+                currentMaterial->Bind(commandBuffer);
+            } 
+
+            if (currentModel != model)
+            {
+                currentModel = model;
+                currentModel->Bind(commandBuffer);
+            }
+
+            model->Draw(commandBuffer, i);
+        }
+
+        currentModel = nullptr;
+        currentMaterial = nullptr;
+    }
+
+    void ModelRenderer::Flush()
+    {
+        transforms.Clear();
+        models.Clear();
+    }
+
+    void ModelRenderer::RecreateMaterials()
+    {
+        if (currentMaterial) currentMaterial->RecreatePipeline();
+    }
+}

--- a/src/Renderer/Renderers/Renderer3D/ModelRenderer.h
+++ b/src/Renderer/Renderers/Renderer3D/ModelRenderer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "../../Core.h"
+#include "../../Model/Model.h"
+#include "../../Utils/Math.h"
+
+namespace SnekVk
+{
+    class ModelRenderer
+    {
+        public:
+
+        ModelRenderer();
+        ~ModelRenderer();
+
+        void Initialise(const char* globalDataAttributeName, const u64& globalDataSize);
+        void Destroy();
+
+        void DrawModel(Model* model, const glm::vec3& position, const glm::vec3& scale, const glm::vec3& rotation);
+
+        void Render(VkCommandBuffer& commandBuffer, const u64& globalDataSize, const void* globalData);
+
+        void Flush();
+
+        void RecreateMaterials();
+
+        private:
+
+        // TODO(Aryeh): Make this configurable via macros
+        static constexpr size_t MAX_OBJECT_TRANSFORMS = 1000;
+
+        Utils::StringId globalDataId;
+        Utils::StringId transformId;
+
+        Utils::StackArray<Model::Transform, MAX_OBJECT_TRANSFORMS> transforms;
+        Utils::StackArray<Model*, MAX_OBJECT_TRANSFORMS> models;
+
+        Material* currentMaterial {nullptr}; 
+        Model* currentModel {nullptr};
+    };
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -377,7 +377,7 @@ int main()
         SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -0.5f}, {4.f, 1.f, -0.5f}, {1.f, 1.f, 1.f});
         SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -1.5f}, {4.f, 1.f, -1.5f}, {1.f, 1.f, 1.f});
 
-        SnekVk::Renderer3D::DrawRect({0.f, -2.f, 0.f}, {1.f, 1.f}, {1.f, 1.f, 1.f});
+        SnekVk::Renderer3D::DrawGrid(10, 1, {1.f, 1.f});
         
         for (auto& shape : shapes)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,6 +329,8 @@ int main()
 
     renderer.SetMainCamera(&camera);
 
+    SnekVk::Renderer3D::EnableGrid();
+
     while(!window.WindowShouldClose()) {
         
         auto newTime = std::chrono::high_resolution_clock::now();
@@ -358,8 +360,6 @@ int main()
         }
 
         if (!renderer.StartFrame()) continue;
-
-        //SnekVk::Renderer3D::DrawGrid(60, 60, {1.f, 0.f, 1.f});
         
         for (auto& shape : shapes)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,13 +216,6 @@ int main()
         .WithStorage(0, "objectBuffer", sizeof(SnekVk::Model::Transform2D), 1000)
         .WithUniform(1, "globalData", sizeof(SnekVk::Renderer2D::GlobalData));
 
-    auto pointLightVertShader = SnekVk::Shader::BuildShader()
-        .FromShader("shaders/pointLight.vert.spv")
-        .WithStage(SnekVk::PipelineConfig::VERTEX)
-        .WithVertexType(sizeof(glm::vec2))
-        .WithVertexAttribute(0, SnekVk::VertexDescription::VEC2)
-        .WithUniform(0, "globalData", sizeof(SnekVk::Renderer3D::GlobalData));
-
     // Fragment shaders
 
     auto fragShader = SnekVk::Shader::BuildShader()
@@ -233,21 +226,15 @@ int main()
         .FromShader("shaders/diffuseFragShader.frag.spv")
         .WithStage(SnekVk::PipelineConfig::FRAGMENT)
         .WithUniform(1, "globalData", sizeof(SnekVk::Renderer3D::GlobalData)); // TIL: bindings must be unique accross all available shaders 
-    
-    auto pointLightFragShader = SnekVk::Shader::BuildShader()
-        .FromShader("shaders/pointLight.frag.spv")
-        .WithStage(SnekVk::PipelineConfig::FRAGMENT)
-        .WithUniform(0, "globalData", sizeof(SnekVk::Renderer3D::GlobalData));
-
 
     // Material Declaration
                                 // vertex       // fragment  
     SnekVk::Material diffuseMat(&diffuseShader, &diffuseFragShader); // 3D diffuse material
     SnekVk::Material spriteMat(&spriteShader, &fragShader);  // 2D sprite material 
 
-    SnekVk::Material pointLightMat(&pointLightVertShader, &pointLightFragShader); // point light shader
+    //SnekVk::Material pointLightMat(&pointLightVertShader, &pointLightFragShader); // point light shader
 
-    SnekVk::Material::BuildMaterials({&diffuseMat, &spriteMat, &pointLightMat});
+    SnekVk::Material::BuildMaterials({&diffuseMat, &spriteMat});
 
     // Generate models
 
@@ -255,8 +242,6 @@ int main()
 
     SnekVk::Model triangleModel(triangleMeshData);
     SnekVk::Model squareModel(squareMeshData);
-
-    SnekVk::Model pointLightModel(rawSquareMeshData);
 
     // Generating models from .obj files
 
@@ -270,8 +255,6 @@ int main()
     // Set 3D diffuse material
     cubeObjModel.SetMaterial(&diffuseMat);
     vaseObjModel.SetMaterial(&diffuseMat);
-
-    pointLightModel.SetMaterial(&pointLightMat);
 
     // Create shapes for use
     std::vector<Components::Shape> shapes = 
@@ -319,8 +302,6 @@ int main()
         {1.f, 1.f, 1.f, .02f}
     );
 
-    light.SetModel(&pointLightModel);
-
     renderer.SetPointLight(&light);
 
     auto currentTime = std::chrono::high_resolution_clock::now();
@@ -365,7 +346,7 @@ int main()
         }
 
         // TODO(Aryeh): This will eventually need to take in multiple lights.
-        SnekVk::Renderer3D::DrawLight(&pointLightModel);
+        SnekVk::Renderer3D::DrawLight({0.0f, -1.f, -1.5f}, 0.05f, {1.f, 0.f, 0.f, alpha}, {1.f, 1.f, 1.f, .02f});
         
         SnekVk::Renderer3D::DrawBillboard({-1.f, -2.5f, 0.f}, {1.f, 1.f}, {1.f, 1.f, 1.f, 1.f});
         SnekVk::Renderer3D::DrawBillboard({1.f, -2.5f, 0.f}, {1.f, 1.f}, {1.f, 0.f, 0.f, 1.f});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,8 +369,8 @@ int main()
         // TODO(Aryeh): This will eventually need to take in multiple lights.
         SnekVk::Renderer3D::DrawLight(&pointLightModel);
         
-        SnekVk::Renderer3D::DrawBillboard({0.f, -2.f, -0.f}, {1.f, 1.f}, {1.f, 0.f, 0.f, 1.f});
-        SnekVk::Renderer3D::DrawBillboard({0.0f, -1.5f, -0.f}, {1.f, 1.f}, {1.f, 1.f, 1.f, 1.f});
+        SnekVk::Renderer3D::DrawBillboard({-1.f, -2.5f, 0.f}, {1.f, 1.f}, {1.f, 1.f, 1.f, 1.f});
+        SnekVk::Renderer3D::DrawBillboard({1.f, -2.5f, 0.f}, {1.f, 1.f}, {1.f, 0.f, 0.f, 1.f});
 
         for (auto& shape : shapes2D)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -377,7 +377,7 @@ int main()
         SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -0.5f}, {4.f, 1.f, -0.5f}, {1.f, 1.f, 1.f});
         SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -1.5f}, {4.f, 1.f, -1.5f}, {1.f, 1.f, 1.f});
 
-        SnekVk::Renderer3D::DrawGrid(10, 1, {1.f, 1.f});
+        SnekVk::Renderer3D::DrawGrid(3, 2, {1.f, 1.f});
         
         for (auto& shape : shapes)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,8 +369,6 @@ int main()
         // TODO(Aryeh): This will eventually need to take in multiple lights.
         SnekVk::Renderer3D::DrawLight(&pointLightModel);
 
-        SnekVk::Renderer3D::DrawLine({0.f, 0.f, 0.f}, {10.f, -1.f, 0.f}, {1.f, 0.f, 0.f});
-
         for (auto& shape : shapes2D)
         {
             SnekVk::Renderer2D::DrawModel(shape.GetModel(), shape.GetPosition2D(), shape.GetScale2D(), shape.GetRotation2D(), shape.GetZIndex());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -239,6 +239,7 @@ int main()
         .WithStage(SnekVk::PipelineConfig::FRAGMENT)
         .WithUniform(0, "globalData", sizeof(SnekVk::Renderer3D::GlobalData));
 
+
     // Material Declaration
                                 // vertex       // fragment  
     SnekVk::Material diffuseMat(&diffuseShader, &diffuseFragShader); // 3D diffuse material
@@ -292,7 +293,7 @@ int main()
     shapes[0].SetColor({.5f, 0.f, 0.f});
 
     shapes[1].SetPosition({0.f, 0.f, 0.f});
-    shapes[1].SetScale({3.f, 3.f, 0.0001f});
+    shapes[1].SetScale({3.f, 3.f, 0.01f});
     shapes[1].SetColor({.5f, 0.f, 0.f});
     shapes[1].SetRotationX(1.570796f);
 
@@ -358,7 +359,7 @@ int main()
 
         if (!renderer.StartFrame()) continue;
 
-        SnekVk::Renderer3D::DrawGrid(30, 30, {1.f, 0.f, 1.f});
+        //SnekVk::Renderer3D::DrawGrid(60, 60, {1.f, 0.f, 1.f});
         
         for (auto& shape : shapes)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -292,7 +292,7 @@ int main()
     shapes[0].SetColor({.5f, 0.f, 0.f});
 
     shapes[1].SetPosition({0.f, 1.f, 2.5f});
-    shapes[1].SetScale({3.f, 3.f, 0.001f});
+    shapes[1].SetScale({3.f, 3.f, 0.01f});
     shapes[1].SetColor({.5f, 0.f, 0.f});
     shapes[1].SetRotationX(1.570796f);
 
@@ -376,6 +376,8 @@ int main()
         SnekVk::Renderer3D::DrawLine({-4.f, 1.f, 0.5f}, {4.f, 1.f, 0.5f}, {1.f, 1.f, 1.f});
         SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -0.5f}, {4.f, 1.f, -0.5f}, {1.f, 1.f, 1.f});
         SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -1.5f}, {4.f, 1.f, -1.5f}, {1.f, 1.f, 1.f});
+
+        SnekVk::Renderer3D::DrawRect({0.f, -2.f, 0.f}, {1.f, 1.f}, {1.f, 1.f, 1.f});
         
         for (auto& shape : shapes)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,6 +369,8 @@ int main()
         // TODO(Aryeh): This will eventually need to take in multiple lights.
         SnekVk::Renderer3D::DrawLight(&pointLightModel);
 
+        SnekVk::Renderer3D::DrawLine({0.f, 0.f, 0.f}, {10.f, -1.f, 0.f}, {1.f, 0.f, 0.f});
+
         for (auto& shape : shapes2D)
         {
             SnekVk::Renderer2D::DrawModel(shape.GetModel(), shape.GetPosition2D(), shape.GetScale2D(), shape.GetRotation2D(), shape.GetZIndex());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -314,7 +314,7 @@ int main()
     // Lights
 
     SnekVk::PointLight light(
-        {0.0f, -1.0f, -1.5f}, 
+        {0.0f, -1.f, -1.5f}, 
         {1.f, 0.f, 0.f, 1.0f}, 
         {1.f, 1.f, 1.f, .02f}
     );
@@ -368,6 +368,9 @@ int main()
 
         // TODO(Aryeh): This will eventually need to take in multiple lights.
         SnekVk::Renderer3D::DrawLight(&pointLightModel);
+        
+        SnekVk::Renderer3D::DrawBillboard({0.f, -2.f, -0.f}, {1.f, 1.f}, {1.f, 0.f, 0.f, 1.f});
+        SnekVk::Renderer3D::DrawBillboard({0.0f, -1.5f, -0.f}, {1.f, 1.f}, {1.f, 1.f, 1.f, 1.f});
 
         for (auto& shape : shapes2D)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -294,16 +294,6 @@ int main()
 
     cameraObject.SetPosition({0.f, -1.f, -2.5f});
 
-    // Lights
-
-    SnekVk::PointLight light(
-        {0.0f, -1.f, -1.5f}, 
-        {1.f, 0.f, 0.f, 1.0f}, 
-        {1.f, 1.f, 1.f, .02f}
-    );
-
-    renderer.SetPointLight(&light);
-
     auto currentTime = std::chrono::high_resolution_clock::now();
 
     bool inputEnabled = true;
@@ -317,8 +307,6 @@ int main()
         currentTime = newTime;
 
         auto alpha = std::clamp<float>(abs(sin(glfwGetTime())), 0.001f, 1.f);
-        
-        light.SetColor({1.f, 0.f, 0.f, alpha});
 
         window.Update();
 
@@ -346,10 +334,12 @@ int main()
         }
 
         // TODO(Aryeh): This will eventually need to take in multiple lights.
-        SnekVk::Renderer3D::DrawLight({0.0f, -1.f, -1.5f}, 0.05f, {1.f, 0.f, 0.f, alpha}, {1.f, 1.f, 1.f, .02f});
+        SnekVk::Renderer3D::DrawPointLight({0.0f, -1.f, -1.5f}, 0.05f, {1.f, 0.f, 0.f, alpha}, {1.f, 1.f, 1.f, .02f});
         
         SnekVk::Renderer3D::DrawBillboard({-1.f, -2.5f, 0.f}, {1.f, 1.f}, {1.f, 1.f, 1.f, 1.f});
         SnekVk::Renderer3D::DrawBillboard({1.f, -2.5f, 0.f}, {1.f, 1.f}, {1.f, 0.f, 0.f, 1.f});
+
+        SnekVk::Renderer3D::DrawLine({0.0f, -1.f, -1.5f}, {0.f, -1.f, 0.f}, {1.f, 1.f, 1.f});
 
         for (auto& shape : shapes2D)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,8 +329,6 @@ int main()
 
     renderer.SetMainCamera(&camera);
 
-    SnekVk::Renderer3D::EnableGrid();
-
     while(!window.WindowShouldClose()) {
         
         auto newTime = std::chrono::high_resolution_clock::now();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -287,32 +287,33 @@ int main()
         Components::Shape(&squareModel)
     };
 
-    shapes[0].SetPosition({0.f, .5f, 2.5f});
+    shapes[0].SetPosition({0.f, -.5f, 0.f});
     shapes[0].SetScale({.5f, .5f, .5f});
     shapes[0].SetColor({.5f, 0.f, 0.f});
 
-    shapes[1].SetPosition({0.f, 1.f, 2.5f});
-    shapes[1].SetScale({3.f, 3.f, 0.01f});
+    shapes[1].SetPosition({0.f, 0.f, 0.f});
+    shapes[1].SetScale({3.f, 3.f, 0.0001f});
     shapes[1].SetColor({.5f, 0.f, 0.f});
     shapes[1].SetRotationX(1.570796f);
 
-    shapes[2].SetPosition({0.f, 0.f, 2.5f});
+    shapes[2].SetPosition({0.f, -1.f, 0.f});
     shapes[2].SetScale({2.f, 2.f, 2.f});
     shapes[2].SetColor({.5f, 0.f, 0.f});
 
-    shapes2D[0].SetPosition2D({1.5f, 0.f});
+    shapes2D[0].SetPosition2D({1.5f, -1.f});
     shapes2D[0].SetScale2D({.5f, 0.5f});
-    shapes2D[0].SetRotation2D(10.f);
-    shapes2D[0].SetZIndex(2.5f);
+    shapes2D[0].SetZIndex(0.f);
 
-    shapes2D[1].SetPosition2D({-1.5f, 0.f});
+    shapes2D[1].SetPosition2D({-1.5f, -1.f});
     shapes2D[1].SetScale2D({.5f, 0.5f});
-    shapes2D[1].SetZIndex(2.5f);
+    shapes2D[1].SetZIndex(0.f);
+
+    cameraObject.SetPosition({0.f, -1.f, -2.5f});
 
     // Lights
 
     SnekVk::PointLight light(
-        {0.0f, -1.0f, 1.5f}, 
+        {0.0f, -1.0f, -1.5f}, 
         {1.f, 0.f, 0.f, 1.0f}, 
         {1.f, 1.f, 1.f, .02f}
     );
@@ -357,27 +358,7 @@ int main()
 
         if (!renderer.StartFrame()) continue;
 
-        SnekVk::Renderer3D::DrawLine({4.f, 1.f, -1.5f}, {4.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({3.f, 1.f, -1.5f}, {3.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({2.f, 1.f, -1.5f}, {2.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({1.f, 1.f, -1.5f}, {1.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({0.f, 1.f, -1.5f}, {0.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-1.f, 1.f, -1.5f}, {-1.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-2.f, 1.f, -1.5f}, {-2.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-3.f, 1.f, -1.5f}, {-3.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -1.5f}, {-4.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, 6.5f}, {4.f, 1.f, 6.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, 5.5f}, {4.f, 1.f, 5.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, 4.5f}, {4.f, 1.f, 4.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, 3.5f}, {4.f, 1.f, 3.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, 2.5f}, {4.f, 1.f, 2.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, 1.5f}, {4.f, 1.f, 1.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, 0.5f}, {4.f, 1.f, 0.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -0.5f}, {4.f, 1.f, -0.5f}, {1.f, 1.f, 1.f});
-        SnekVk::Renderer3D::DrawLine({-4.f, 1.f, -1.5f}, {4.f, 1.f, -1.5f}, {1.f, 1.f, 1.f});
-
-        SnekVk::Renderer3D::DrawGrid(3, 2, {1.f, 1.f});
+        SnekVk::Renderer3D::DrawGrid(30, 30, {1.f, 0.f, 1.f});
         
         for (auto& shape : shapes)
         {


### PR DESCRIPTION
Edited the Rendering architecture to include a number of Render modules. Each module is responsible for rendering individual components (such as lights and models). This PR also includes a GPU-based grid which can be activated by building the project with the ENABLE_GRID flag set. This can be done by adding `CSSFLAGS="-DENABLE_GRID"` when running the build command.