### PR TITLE
[1/12] Added Colors as a Vertex Attribute

### DIFF
--- a/shaders/simpleShader.frag
+++ b/shaders/simpleShader.frag
@@ -2,6 +2,9 @@
 
 layout (location = 0) out vec4 outColor;
 
+// The color being passed in from the vertex stage
+layout (location = 0) in vec3 fragColor;
+
 void main() {
-    outColor = vec4(0.0, 1.0, 0.5, 1.0);
+    outColor = vec4(fragColor, 1.0);
 }

--- a/shaders/simpleShader.vert
+++ b/shaders/simpleShader.vert
@@ -2,7 +2,11 @@
 
 // 'in' keyword specifies that position gets data from a buffer
 layout(location = 0) in vec2 position;
+layout(location = 1) in vec3 color;
+ 
+layout(location = 0) out vec3 fragColor;
 
 void main() {
     gl_Position = vec4(position, 0.0, 1.0);
+    fragColor = color;
 }

--- a/src/Renderer/Model/Model.cpp
+++ b/src/Renderer/Model/Model.cpp
@@ -79,14 +79,19 @@ namespace SnekVk
         return bindingDescriptions;
     }
 
-    std::array<VkVertexInputAttributeDescription, 1> Model::Vertex::GetAttributeDescriptions()
+    std::array<VkVertexInputAttributeDescription, 2> Model::Vertex::GetAttributeDescriptions()
     {
-        std::array<VkVertexInputAttributeDescription, 1> attributeDescriptions;
+        std::array<VkVertexInputAttributeDescription, 2> attributeDescriptions;
 
         attributeDescriptions[0].binding = 0;
         attributeDescriptions[0].location = 0;
-        attributeDescriptions[0].format = VK_FORMAT_R32G32_SFLOAT; // equivalent to a vec2
-        attributeDescriptions[0].offset = 0;
+        attributeDescriptions[0].format = VK_FORMAT_R32G32_SFLOAT;
+        attributeDescriptions[0].offset = offsetof(Vertex, position);
+
+        attributeDescriptions[1].binding = 0;
+        attributeDescriptions[1].location = 1;
+        attributeDescriptions[1].format = VK_FORMAT_R32G32B32_SFLOAT;
+        attributeDescriptions[1].offset = offsetof(Vertex, color);
         return attributeDescriptions;
     }
 }

--- a/src/Renderer/Model/Model.h
+++ b/src/Renderer/Model/Model.h
@@ -23,6 +23,7 @@ namespace SnekVk
         struct Vertex
         {
             glm::vec2 position;
+            glm::vec3 color;
 
             /**
              * @brief Get a list of binding colorDescriptions for this Vertex. A binding description details
@@ -38,7 +39,7 @@ namespace SnekVk
              * 
              * @return The attribute colorDescriptions in the form of a std::array<VkVertexInputAttributeDescription, 1>
              */
-            static std::array<VkVertexInputAttributeDescription, 1> GetAttributeDescriptions();
+            static std::array<VkVertexInputAttributeDescription, 2> GetAttributeDescriptions();
         };
 
         // 'Structors

--- a/src/Renderer/Swapchain/Swapchain.cpp
+++ b/src/Renderer/Swapchain/Swapchain.cpp
@@ -357,7 +357,7 @@ namespace SnekVk
         for (size_t i = 0; i < formatCount; i++)
         {
             VkSurfaceFormatKHR& availableFormat = formats[i];
-            if (availableFormat.format == VK_FORMAT_B8G8R8A8_UNORM &&
+            if (availableFormat.format == VK_FORMAT_B8G8R8A8_SRGB && 
                 availableFormat.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) return availableFormat;
         }
         // If we can't find what we want then we use whatever is available on the GPU.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,9 +20,9 @@ static const constexpr int WIDTH = 800;
 static const constexpr int HEIGHT = 600;
 
 SnekVk::Model::Vertex triangleVerts[] = {
-    {{0.0f, -0.5f}},
-    {{0.5f, 0.5f}},
-    {{-0.5f, 0.5f}}
+    {{0.0f, -0.5f}, {1.0f, 0.0f, 0.0f}},
+    {{0.5f, 0.5f}, {0.0f, 1.0f, 0.0f}}, 
+    {{-0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}}
 };
 
 int main() 


### PR DESCRIPTION
Added colors to the vertex attributes so that per-vertex color data can be passed into the shaders. 

Running this version should result in a triangle with three colors per vertex:

<img width="801" alt="Screen Shot 2022-05-25 at 11 49 56 am" src="https://user-images.githubusercontent.com/28279568/170161859-1cc430bc-dddb-428f-8c2a-409566626f2b.png">

