### PR TITLE
Added Push Constants to Enable Movement

### DIFF
--- a/shaders/simpleShader.frag
+++ b/shaders/simpleShader.frag
@@ -2,9 +2,11 @@
 
 layout (location = 0) out vec4 outColor;
 
-// The color being passed in from the vertex stage
-layout (location = 0) in vec3 fragColor;
+layout (push_constant) uniform Push {
+    vec2 offset;
+    vec3 color;
+} push;
 
 void main() {
-    outColor = vec4(fragColor, 1.0);
+    outColor = vec4(push.color, 1.0);
 }

--- a/shaders/simpleShader.vert
+++ b/shaders/simpleShader.vert
@@ -3,10 +3,12 @@
 // 'in' keyword specifies that position gets data from a buffer
 layout(location = 0) in vec2 position;
 layout(location = 1) in vec3 color;
- 
-layout(location = 0) out vec3 fragColor;
+
+layout (push_constant) uniform Push {
+    vec2 offset;
+    vec3 color;
+} push;
 
 void main() {
-    gl_Position = vec4(position, 0.0, 1.0);
-    fragColor = color;
+    gl_Position = vec4(position + push.offset, 0.0, 1.0);
 }

--- a/src/Renderer/Model/Model.cpp
+++ b/src/Renderer/Model/Model.cpp
@@ -7,6 +7,7 @@ namespace SnekVk
     Model::Model(VulkanDevice& device, const Vertex* vertices, u32 vertexCount)
         : device{device}, vertexCount{vertexCount}
     {
+        pushConstant = {{0.0f, 0.0f}, {0.0f, 0.0f, 0.0f}};
         CreateVertexBuffers(vertices);
     }
 

--- a/src/Renderer/Model/Model.h
+++ b/src/Renderer/Model/Model.h
@@ -16,7 +16,7 @@ namespace SnekVk
     {
         public:
 
-        struct ModelPushConstantData
+        struct PushConstantData
         {
             glm::vec2 offset;
             alignas(16) glm::vec3 color;
@@ -82,6 +82,10 @@ namespace SnekVk
          */
         void Draw(VkCommandBuffer commandBuffer);
 
+        // TODO: Remove this when no longer relevant. 
+        PushConstantData& GetPushConstant() { return pushConstant; }
+        void SetPushConstant(PushConstantData newData) { pushConstant = newData; }
+
         private:
 
         /**
@@ -95,5 +99,7 @@ namespace SnekVk
         VkBuffer vertexBuffer;
         VkDeviceMemory vertexBufferMemory;
         u32 vertexCount;
+
+        PushConstantData pushConstant;
     };
 }

--- a/src/Renderer/Model/Model.h
+++ b/src/Renderer/Model/Model.h
@@ -16,6 +16,12 @@ namespace SnekVk
     {
         public:
 
+        struct ModelPushConstantData
+        {
+            glm::vec2 offset;
+            alignas(16) glm::vec3 color;
+        };
+
         /**
          * @brief The Vertex struct represents all the vertex data that'll be passed into our shaders.
          * Right now all we expect is a vector 2 for it's position in 2D space. 

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -77,26 +77,20 @@ namespace SnekVk
 
         graphicsPipeline.Bind(commandBuffers[imageIndex]);
 
-        size_t modelIdx = 0;
         for (auto& model : models)
         {
             model->Bind(commandBuffers[imageIndex]);
-
-            Model::ModelPushConstantData data{};
-            data.offset = {-0.5f + frame * 0.01f, -0.4f + modelIdx * 0.25f};
-            data.color = {0.0f, 0.0f, 0.2f + 0.2f * modelIdx};
 
             vkCmdPushConstants(
                 commandBuffers[imageIndex],
                 pipelineLayout,
                 VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
                 0,
-                sizeof(Model::ModelPushConstantData),
-                &data
+                sizeof(Model::PushConstantData),
+                &model->GetPushConstant()
             );
 
             model->Draw(commandBuffers[imageIndex]);
-            modelIdx++;
         }
         
         RenderPass::End(commandBuffers[imageIndex]);
@@ -162,7 +156,7 @@ namespace SnekVk
         VkPushConstantRange range{};
         range.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
         range.offset = 0; 
-        range.size = sizeof(Model::ModelPushConstantData);
+        range.size = sizeof(Model::PushConstantData);
 
         VkPipelineLayoutCreateInfo pipelineLayoutInfo{};
         pipelineLayoutInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,19 +35,30 @@ int main()
 
     renderer.SetClearValue(.1f, .1f, .1f, 1.f);
 
-    SnekVk::Model triangle0(renderer.GetDevice(), triangleVerts, 3);
-    SnekVk::Model triangle1(renderer.GetDevice(), triangleVerts, 3);
-    SnekVk::Model triangle2(renderer.GetDevice(), triangleVerts, 3);
-    SnekVk::Model triangle3(renderer.GetDevice(), triangleVerts, 3);
+    SnekVk::Model models[] = {
+        SnekVk::Model(renderer.GetDevice(), triangleVerts, 3),
+        SnekVk::Model(renderer.GetDevice(), triangleVerts, 3),
+        SnekVk::Model(renderer.GetDevice(), triangleVerts, 3),
+        SnekVk::Model(renderer.GetDevice(), triangleVerts, 3)
+    };
 
-    renderer.SubmitModel(&triangle0);
-    renderer.SubmitModel(&triangle1);
-    renderer.SubmitModel(&triangle2);
-    renderer.SubmitModel(&triangle3);
+    for (size_t i = 0; i < 4; i++) renderer.SubmitModel(&models[i]);
     
     while(!window.WindowShouldClose()) {
+        static int frame = 0;
+        frame = (frame + 1) % 200;
+
         window.Update();
         renderer.ClearDeviceQueue();
+
+        for (int i = 0; i < 4; i++)
+        {
+            models[i].SetPushConstant(
+                {{-0.5f + frame * 0.01f, -0.4f + i * 0.25f}, 
+                {0.0f, 0.0f, 0.2f + 0.2f * i}}
+            );
+        }
+
         renderer.DrawFrame();
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,12 +25,6 @@ SnekVk::Model::Vertex triangleVerts[] = {
     {{-0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}}
 };
 
-SnekVk::Model::Vertex triangleVerts2[] = {
-    {{0.0f, -1.0f}, {1.0f, 0.0f, 0.0f}},
-    {{1.0f, 1.0f}, {1.0f, 0.0f, 0.0f}}, 
-    {{-1.0f, 1.0f}, {1.0f, 0.0f, 0.0f}}
-};
-
 int main() 
 {
     WINDOWS_ATTACH_CONSOLE
@@ -41,11 +35,15 @@ int main()
 
     renderer.SetClearValue(.1f, .1f, .1f, 1.f);
 
-    SnekVk::Model triangle(renderer.GetDevice(), triangleVerts, 3);
-    SnekVk::Model triangle2(renderer.GetDevice(), triangleVerts2, 3);
+    SnekVk::Model triangle0(renderer.GetDevice(), triangleVerts, 3);
+    SnekVk::Model triangle1(renderer.GetDevice(), triangleVerts, 3);
+    SnekVk::Model triangle2(renderer.GetDevice(), triangleVerts, 3);
+    SnekVk::Model triangle3(renderer.GetDevice(), triangleVerts, 3);
 
-    renderer.SubmitModel(&triangle);
+    renderer.SubmitModel(&triangle0);
+    renderer.SubmitModel(&triangle1);
     renderer.SubmitModel(&triangle2);
+    renderer.SubmitModel(&triangle3);
     
     while(!window.WindowShouldClose()) {
         window.Update();


### PR DESCRIPTION
This PR adds push constants to the codebase. This allows us to push changing data into the shaders, therefore simulating movement. 

This PR should result in four triangles moving to the right and re-appearing once they leave the window bounds. 