### PR TITLE
Refactored the RenderPass creation process to include builders

### DIFF
--- a/src/Renderer/RenderPass/RenderPass.cpp
+++ b/src/Renderer/RenderPass/RenderPass.cpp
@@ -38,26 +38,42 @@ namespace SnekVk
 
     RenderPass::RenderPass() = default;
 
-    void RenderPass::Build(VulkanDevice* vulkanDevice,
-                           VkAttachmentDescription *attachments,
-                           u32 attachmentCount,
-                           VkSubpassDescription *subpasses,
-                           u32 subpassCount,
-                           VkSubpassDependency *dependencies,
-                           u32 dependencyCount)
+    void RenderPass::Initialise(VulkanDevice *vulkanDevice, const RenderPass::Config& config)
     {
         device = vulkanDevice;
 
+        auto& attachments = config.GetAttachments();
+        auto& subPasses = config.GetSubPasses();
+        auto& dependencies = config.GetDependencies();
+
         VkRenderPassCreateInfo renderPassCreateInfo{};
         renderPassCreateInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-        renderPassCreateInfo.attachmentCount = attachmentCount;
-        renderPassCreateInfo.pAttachments = attachments;
-        renderPassCreateInfo.subpassCount = subpassCount;
-        renderPassCreateInfo.pSubpasses = subpasses;
-        renderPassCreateInfo.dependencyCount = dependencyCount;
-        renderPassCreateInfo.pDependencies = dependencies;
+        renderPassCreateInfo.attachmentCount = attachments.Count();
+        renderPassCreateInfo.pAttachments = attachments.Data();
+        renderPassCreateInfo.subpassCount = subPasses.Count();
+        renderPassCreateInfo.pSubpasses = subPasses.Data();
+        renderPassCreateInfo.dependencyCount = dependencies.Count();
+        renderPassCreateInfo.pDependencies = dependencies.Data();
 
         SNEK_ASSERT(vkCreateRenderPass(device->Device(), &renderPassCreateInfo, nullptr, OUT &renderPass) == VK_SUCCESS,
                     "Failed to create render pass!")
+    }
+
+    RenderPass::Config &RenderPass::Config::WithAttachment(const VkAttachmentDescription& attachment)
+    {
+        attachments.Append(attachment);
+        return *this;
+    }
+
+    RenderPass::Config &RenderPass::Config::WithSubPass(const VkSubpassDescription& subpass)
+    {
+        subpasses.Append(subpass);
+        return *this;
+    }
+
+    RenderPass::Config &RenderPass::Config::WithDependency(const VkSubpassDependency& dependency)
+    {
+        dependencies.Append(dependency);
+        return *this;
     }
 }

--- a/src/Renderer/RenderPass/RenderPass.cpp
+++ b/src/Renderer/RenderPass/RenderPass.cpp
@@ -59,6 +59,12 @@ namespace SnekVk
                     "Failed to create render pass!")
     }
 
+    void RenderPass::Initialise(VulkanDevice* device, RenderPass &renderpass, const RenderPass::Config &config) {
+        renderpass.Initialise(device, config);
+    }
+
+    // Config functions.
+
     RenderPass::Config &RenderPass::Config::WithAttachment(const VkAttachmentDescription& attachment)
     {
         attachments.Append(attachment);

--- a/src/Renderer/RenderPass/RenderPass.h
+++ b/src/Renderer/RenderPass/RenderPass.h
@@ -18,28 +18,93 @@ namespace SnekVk
     class RenderPass
     {
     public:
+
+        /**
+         * @brief The config class is a container for storing all of our render pass information before creating it.
+         * This class is to be used for storing render pass attachments and subpass information. This class follows the
+         * builder pattern. It is intended to be created via the chaining of functions such as:
+         * ```
+         * RenderPass::CreateConfig().WithAttachment(Attachments::CreateColorAttachment(swapChainImageFormat))
+                                     .WithSubPass(Attachments::CreateSubPass(...)
+                                     .WithDependency(Attachments::CreateSubPassDependency();
+         * ```
+         */
         class Config
         {
         public:
+            /**
+             * @brief A default constructor for the class. Currently does not accept any parameters.
+             */
             Config() = default;
+
+            /**
+             * @brief A default destructor for the class. This class will not be containing any allocated memory, so
+             * a destructor is not needed.
+             */
             ~Config() = default;
 
+            /**
+             * @brief Specifies the maximum number of attachments that can be configured.
+             */
             static constexpr u32 MAX_ATTACHMENTS = 2;
+
+            /**
+             * @brief Specifies the maximum number of subpasses that can be configured.
+             */
             static constexpr u32 MAX_SUBPASSES = 1;
+
+            /**
+             * @brief Specifies the maximum number of subpass dependencies that can be configured.
+             */
             static constexpr u32 MAX_DEPENDENCIES = 1;
 
+            /**
+             * @brief Adds a render pass attachment to the Config class. The number of attachments allowed is based off
+             * the MAX_ATTACHMENTS static variable.
+             * @param attachment the VkAttachmentDescription being added.
+             * @return the current object.
+             */
             Config& WithAttachment(const VkAttachmentDescription& attachment);
+
+            /**
+             * @brief Adds a subpass to the Config class. The number of subpasses allowed is based off
+             * the MAX_SUBPASSES static variable.
+             * @param subpass the VkSubpassDescription to be added.
+             * @return the current object.
+             */
             Config& WithSubPass(const VkSubpassDescription& subpass);
+
+            /**
+             * @brief Adds a subpass dependency to the Config class. The number of dependencies allowed is based off
+             * the MAX_DEPENDENCIES static variable.
+             * @param dependency the VkSubpassDependency to be added.
+             * @return the current object.
+             */
             Config& WithDependency(const VkSubpassDependency& dependency);
 
+            /**
+             * @brief Returns the array storing our attachments.
+             * @return a Utils::StackArray with our renderpass attachments.
+             */
             const Utils::StackArray<VkAttachmentDescription, MAX_ATTACHMENTS>& GetAttachments() const { return attachments; }
+
+            /**
+             * @brief Returns the array storing our subpasses.
+             * @return a Utils::StackArray with our renderpass subpasses.
+             */
             const Utils::StackArray<VkSubpassDescription, MAX_SUBPASSES>& GetSubPasses() const { return subpasses; }
+
+            /**
+             * @brief Returns an array storing our subpass dependencies.
+             * @return a Utils::StackArray with our subpass dependencies.
+             */
             const Utils::StackArray<VkSubpassDependency, MAX_DEPENDENCIES>& GetDependencies() const { return dependencies; }
         private:
             Utils::StackArray<VkAttachmentDescription, MAX_ATTACHMENTS> attachments;
             Utils::StackArray<VkSubpassDescription, MAX_SUBPASSES> subpasses;
             Utils::StackArray<VkSubpassDependency, MAX_DEPENDENCIES> dependencies;
         };
+
         /**
          * @brief An empty constructor. The RenderPass class relies on the Build() method to initialize the Vulkan
          * RenderPass object.
@@ -55,7 +120,19 @@ namespace SnekVk
          */
         void Initialise(VulkanDevice* vulkanDevice, const Config& config);
 
+        /**
+         * @brief A shorthand function for creating an empty Config.
+         * @return an empty Config object.
+         */
         static Config CreateConfig() { return Config{}; }
+
+        /**
+         * @brief A static function for creating a renderpass. Does the same thing as the renderpass' Initialise function.
+         * @param device the VulkanDevice being used.
+         * @param renderpass the RenderPass to be configured.
+         * @param config the RenderPass' configuration options.
+         */
+        static void Initialise(VulkanDevice* device, RenderPass& renderpass, const Config& config);
 
         /**
          * @brief Begins a RenderPass. Any rendering operations that occur will utilise the attachments and operations

--- a/src/Renderer/RenderPass/RenderPass.h
+++ b/src/Renderer/RenderPass/RenderPass.h
@@ -18,6 +18,28 @@ namespace SnekVk
     class RenderPass
     {
     public:
+        class Config
+        {
+        public:
+            Config() = default;
+            ~Config() = default;
+
+            static constexpr u32 MAX_ATTACHMENTS = 2;
+            static constexpr u32 MAX_SUBPASSES = 1;
+            static constexpr u32 MAX_DEPENDENCIES = 1;
+
+            Config& WithAttachment(const VkAttachmentDescription& attachment);
+            Config& WithSubPass(const VkSubpassDescription& subpass);
+            Config& WithDependency(const VkSubpassDependency& dependency);
+
+            const Utils::StackArray<VkAttachmentDescription, MAX_ATTACHMENTS>& GetAttachments() const { return attachments; }
+            const Utils::StackArray<VkSubpassDescription, MAX_SUBPASSES>& GetSubPasses() const { return subpasses; }
+            const Utils::StackArray<VkSubpassDependency, MAX_DEPENDENCIES>& GetDependencies() const { return dependencies; }
+        private:
+            Utils::StackArray<VkAttachmentDescription, MAX_ATTACHMENTS> attachments;
+            Utils::StackArray<VkSubpassDescription, MAX_SUBPASSES> subpasses;
+            Utils::StackArray<VkSubpassDependency, MAX_DEPENDENCIES> dependencies;
+        };
         /**
          * @brief An empty constructor. The RenderPass class relies on the Build() method to initialize the Vulkan
          * RenderPass object.
@@ -28,21 +50,12 @@ namespace SnekVk
          * @brief Initialises the RenderPass. Creating a RenderPass requires us to explicitly state what operations
          * the RenderPass will be responsible for, along with any graphics stages the renderpass may rely on.
          *
-         * @param vulkanDevice The device being used to allocate memory from for these operations
-         * @param attachments Attachments are explicit declarations of the stages we wish to use in our graphics pipeline
-         * @param attachmentCount The number of attachments the RenderPass is using
-         * @param subpasses Specifies any sub operations we wish to accomplish within the RenderPass
-         * @param subpassCount The number of subpasses
-         * @param dependencies Any dependencies the pipeline may rely on
-         * @param dependencyCount The number of dependencies the RenderPass has
+         * @param vulkanDevice The device instance being used to crete the render pass
+         * @param config Config variables used to create the renderpass
          */
-        void Build(VulkanDevice* vulkanDevice,
-                   VkAttachmentDescription* attachments,
-                   u32 attachmentCount,
-                   VkSubpassDescription* subpasses,
-                   u32 subpassCount,
-                   VkSubpassDependency* dependencies,
-                   u32 dependencyCount);
+        void Initialise(VulkanDevice* vulkanDevice, const Config& config);
+
+        static Config CreateConfig() { return Config{}; }
 
         /**
          * @brief Begins a RenderPass. Any rendering operations that occur will utilise the attachments and operations

--- a/src/Renderer/RenderPass/Utils/Attachments.cpp
+++ b/src/Renderer/RenderPass/Utils/Attachments.cpp
@@ -118,4 +118,54 @@ namespace SnekVk
     {
         return CreateAttachmentReference(attachment, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     }
+
+    Attachments::SubPassBuilder &Attachments::SubPassBuilder::WithColorReference(VkAttachmentReference reference) {
+        colorReferences.Append(reference);
+        return *this;
+    }
+
+    Attachments::SubPassBuilder &Attachments::SubPassBuilder::WithDepthReference(VkAttachmentReference reference) {
+        depthReference = reference;
+        return *this;
+    }
+
+    VkSubpassDescription Attachments::SubPassBuilder::BuildGraphicsSubPass() {
+        return CreateGraphicsSubpass(colorReferences.Count(),
+                                     colorReferences.Data(),
+                                     &depthReference);
+    }
+
+    Attachments::DependencyBuilder &Attachments::DependencyBuilder::WithSrcSubPass(u32 subpass) {
+        srcSubpass = subpass;
+        return *this;
+    }
+
+    Attachments::DependencyBuilder &Attachments::DependencyBuilder::WithDstSubPass(u32 subpass) {
+        dstSubpass = subpass;
+        return *this;
+    }
+
+    Attachments::DependencyBuilder &Attachments::DependencyBuilder::WithSrcStageMask(VkPipelineStageFlags stageMask) {
+        srcStageMask = stageMask;
+        return *this;
+    }
+
+    Attachments::DependencyBuilder &Attachments::DependencyBuilder::WithDstStageMask(VkPipelineStageFlags stageMask) {
+        dstStageMask = stageMask;
+        return *this;
+    }
+
+    Attachments::DependencyBuilder &Attachments::DependencyBuilder::WithSrcAccessMask(VkAccessFlags accessMask) {
+        srcStageMask = accessMask;
+        return *this;
+    }
+
+    Attachments::DependencyBuilder &Attachments::DependencyBuilder::WithDstAccessMask(VkAccessFlags accessMask) {
+        dstStageMask = accessMask;
+        return *this;
+    }
+
+    VkSubpassDependency Attachments::DependencyBuilder::Build() {
+        return CreateDependency(srcSubpass, dstSubpass, srcStageMask, dstStageMask, srcAccessMask, dstAccessMask);
+    }
 }

--- a/src/Renderer/RenderPass/Utils/Attachments.cpp
+++ b/src/Renderer/RenderPass/Utils/Attachments.cpp
@@ -119,6 +119,8 @@ namespace SnekVk
         return CreateAttachmentReference(attachment, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     }
 
+    // SubPassBuilder functions
+
     Attachments::SubPassBuilder &Attachments::SubPassBuilder::WithColorReference(VkAttachmentReference reference) {
         colorReferences.Append(reference);
         return *this;
@@ -134,6 +136,8 @@ namespace SnekVk
                                      colorReferences.Data(),
                                      &depthReference);
     }
+
+    // DependencyBuilder Functions
 
     Attachments::DependencyBuilder &Attachments::DependencyBuilder::WithSrcSubPass(u32 subpass) {
         srcSubpass = subpass;

--- a/src/Renderer/RenderPass/Utils/Attachments.h
+++ b/src/Renderer/RenderPass/Utils/Attachments.h
@@ -4,36 +4,153 @@
 
 namespace SnekVk
 {
+    /**
+     * @brief The Attachments class is intended to act as a static class full of utility functions for building Vulkan
+     * objects. The class contains functions for:
+     * 1) Creating subpasses.
+     * 2) Creating subpass dependencies.
+     * 3) Creating attachments.
+     */
     class Attachments
     {
     public:
-        // TODO: document these builders
+
+        /**
+         * @brief A builder class for creating a VkSubpassDescription. This class follows the builder pattern and is
+         * intended to utilise function chaining to create data members. For example:
+         *
+         * ```
+         * VkSubpassDescription subpass = SubPassBuilder()
+         *                                    .WithColorReference(...)
+         *                                    .WithDepthReference(...)
+         *                                    .BuildGraphicsSubPass()
+         * ```
+         */
         class SubPassBuilder
         {
         public:
+
+            static constexpr u32 MAX_COLOR_REFERENCES = 2;
+
+            /**
+             * @brief A default constructor for the SubPassBuilder.
+             */
             SubPassBuilder() = default;
+
+            /**
+             * @brief A default destructor for the SubPassBuilder.
+             */
             ~SubPassBuilder() = default;
 
+            /**
+             * @brief Adds a color reference. A VkAttachmentReference is a struct in which the index of a needed
+             * attachment is specified, along with the desired image layout when the attachment is complete. The maximum
+             * number of color references is equal to the MAX_COLOR_REFERENCES static variable.
+             * @param reference the VkAttachmentReference being added.
+             * @return the current builder object.
+             */
             SubPassBuilder& WithColorReference(VkAttachmentReference reference);
+
+            /**
+             * @brief Adds a depth reference. Only one depth reference can be used per subpass.
+             * @param reference the VkAttachmentReference sttoring our depth data.
+             * @return the current builder object.
+             */
             SubPassBuilder& WithDepthReference(VkAttachmentReference reference);
+
+            /**
+             * @brief Builds a VkSubpassDescription using the inputted attachment references.
+             * @return a VkSubpassDescription with all the inputted data.
+             */
             VkSubpassDescription BuildGraphicsSubPass();
         private:
-            Utils::StackArray<VkAttachmentReference, 2> colorReferences;
+            // A subpass can contain multiple color references
+            Utils::StackArray<VkAttachmentReference, MAX_COLOR_REFERENCES> colorReferences;
+
+            // A subpass can only contain a single depth reference.
             VkAttachmentReference depthReference {};
         };
 
+        /**
+         * @brief A builder class for creating a subpass dependency. Subpass dependencies allow us to specify an order
+         * in which subpasses must be processed. If a subpass requires the output of another subpass, we can specify
+         * which stages we need to wait for before starting the rendering process.
+         *
+         * This class follows the builder pattern and isvintended to utilise function chaining to create data members.
+         * For example:
+         *
+         * ```
+         * DependencyBuilder builder = DependencyBuilder()
+         *                                 .WithSrcSubPass(...)
+         *                                 .WithDstSubPass(...)
+         *                                 ...
+         *                                 .Build();
+         * ```
+         */
         class DependencyBuilder
         {
         public:
+            /**
+             * @brief A default constructor for the DependencyBuilder.
+             */
             DependencyBuilder() = default;
+
+            /**
+             * @brief A default destructor for the DependencyBuilder.
+             */
             ~DependencyBuilder() = default;
 
+            /**
+             * @brief Specifies the index of the subpass that we depend on. Execution of this subpass will not occur
+             * until the subpass in this index is complete.
+             * @param subpass the index of the subpass we depend on.
+             * @return the current builder object.
+             */
             DependencyBuilder& WithSrcSubPass(u32 subpass);
+
+            /**
+             * @brief Specifies the index of the current subpass. This will pick the appropriate subpass for us to use
+             * once the dependant subpass is complete.
+             * @param subpass the index of the current subpass.
+             * @return the current builder object.
+             */
             DependencyBuilder& WithDstSubPass(u32 subpass);
+
+            /**
+             * @brief Specifies which rendering processes need to be complete before moving onto the current subpass.
+             * @param stageMask a set of stage flags which specify the stages which need to be complete before
+             * evaulating this subpass.
+             * @return the current builder object.
+             */
             DependencyBuilder& WithSrcStageMask(VkPipelineStageFlags stageMask);
+
+            /**
+             * @brief Specifies which stage masks the current subpass will be executing. This creates a dependency where
+             * the dstStageMasks can't be executed until the srcStageMasks are complete.
+             * @param stageMask a set of stage flags which this subpass will execute.
+             * @return the current builder object.
+             */
             DependencyBuilder& WithDstStageMask(VkPipelineStageFlags stageMask);
+
+            /**
+             * @brief Specifies which memory access types will be used by the subpass we depend on.
+             * @param accessMask a set of stage flags specifying the memory access type used.
+             * @return the current builder object.
+             */
             DependencyBuilder& WithSrcAccessMask(VkAccessFlags accessMask);
+
+            /**
+             * @brief Specifies the memory access types used by the current subpass after the subpass it depends on
+             * is complete.
+             * @param accessMask a set of stage flags specifying the memory access required.
+             * @return the current builder object
+             */
             DependencyBuilder& WithDstAccessMask(VkAccessFlags accessMask);
+
+            /**
+             * @brief Uses all data inserted into the builder and returns a VkSubpassDependency.
+             * @return a VkSubpassDependency with all of the dependency data.
+             */
             VkSubpassDependency Build();
         private:
             u32 srcSubpass;
@@ -44,8 +161,16 @@ namespace SnekVk
             VkAccessFlags dstAccessMask;
         };
 
+        /**
+         * @brief A shorthand function for creating a SubPassBuilder.
+         * @return an empty SubPassBuilder object.
+         */
         static SubPassBuilder CreateSubPass() { return SubPassBuilder{}; }
 
+        /**
+         * @brief A shorthand function for creating a DependencyBuilder.
+         * @return an empty DependencyBuilder object.
+         */
         static DependencyBuilder CreateSubPassDependency() { return DependencyBuilder{}; }
 
         /**

--- a/src/Renderer/RenderPass/Utils/Attachments.h
+++ b/src/Renderer/RenderPass/Utils/Attachments.h
@@ -7,6 +7,47 @@ namespace SnekVk
     class Attachments
     {
     public:
+        // TODO: document these builders
+        class SubPassBuilder
+        {
+        public:
+            SubPassBuilder() = default;
+            ~SubPassBuilder() = default;
+
+            SubPassBuilder& WithColorReference(VkAttachmentReference reference);
+            SubPassBuilder& WithDepthReference(VkAttachmentReference reference);
+            VkSubpassDescription BuildGraphicsSubPass();
+        private:
+            Utils::StackArray<VkAttachmentReference, 2> colorReferences;
+            VkAttachmentReference depthReference {};
+        };
+
+        class DependencyBuilder
+        {
+        public:
+            DependencyBuilder() = default;
+            ~DependencyBuilder() = default;
+
+            DependencyBuilder& WithSrcSubPass(u32 subpass);
+            DependencyBuilder& WithDstSubPass(u32 subpass);
+            DependencyBuilder& WithSrcStageMask(VkPipelineStageFlags stageMask);
+            DependencyBuilder& WithDstStageMask(VkPipelineStageFlags stageMask);
+            DependencyBuilder& WithSrcAccessMask(VkAccessFlags accessMask);
+            DependencyBuilder& WithDstAccessMask(VkAccessFlags accessMask);
+            VkSubpassDependency Build();
+        private:
+            u32 srcSubpass;
+            u32 dstSubpass;
+            VkPipelineStageFlags srcStageMask;
+            VkPipelineStageFlags dstStageMask;
+            VkAccessFlags srcAccessMask;
+            VkAccessFlags dstAccessMask;
+        };
+
+        static SubPassBuilder CreateSubPass() { return SubPassBuilder{}; }
+
+        static DependencyBuilder CreateSubPassDependency() { return DependencyBuilder{}; }
+
         /**
          * @brief Creates a default Color Attachment.
          *

--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -92,7 +92,7 @@ namespace SnekVk
         vkFreeCommandBuffers(
             device.Device(), 
             device.GetCommandPool(), 
-            swapChain.GetImageCount(), 
+            SwapChain::GetImageCount(),
             commandBuffers.Data());
     }
 

--- a/src/Renderer/Swapchain/Swapchain.cpp
+++ b/src/Renderer/Swapchain/Swapchain.cpp
@@ -1,7 +1,5 @@
 #include "Swapchain.h"
 
-#include <array>
-
 namespace SnekVk
 {
     // TODO: Fix the warnings
@@ -193,7 +191,8 @@ namespace SnekVk
     {
         swapChainImageFormat = GetSwapChainImageFormat();
         swapChainDepthFormat = FindDepthFormat();
-        renderPass.Initialise(&device,
+        RenderPass::Initialise(&device,
+                               OUT renderPass,
                               RenderPass::CreateConfig()
                               .WithAttachment(Attachments::CreateColorAttachment(swapChainImageFormat))
                               .WithAttachment(Attachments::CreateDepthAttachment(swapChainDepthFormat))

--- a/src/Renderer/Swapchain/Swapchain.h
+++ b/src/Renderer/Swapchain/Swapchain.h
@@ -227,10 +227,9 @@ namespace SnekVk
 
         // Device and window data
         VulkanDevice& device;
+        VkExtent2D windowExtent;
 
         static SwapChain* instance;
-
-        VkExtent2D windowExtent;
 
         // frame buffers and renderpasses
         // TODO: Refactor this into a HeapArray

--- a/src/Renderer/Swapchain/Swapchain.h
+++ b/src/Renderer/Swapchain/Swapchain.h
@@ -84,7 +84,7 @@ namespace SnekVk
          * 
          * @return u32 representing the number of possible active simultaneous images. 
          */
-        u32 GetImageCount() { return FrameImages::GetImageCount(); }
+        static u32 GetImageCount() { return FrameImages::GetImageCount(); }
 
         /**
          * @brief The the raw Vulkan swapchain struct. 
@@ -98,14 +98,14 @@ namespace SnekVk
          * 
          * @return u32 representing the width of the image. 
          */
-        u32 GetWidth() { return swapChainExtent.width; }
+        u32 GetWidth() const { return swapChainExtent.width; }
 
         /**
          * @brief Get the swapchain image height.
          * 
          * @return u32 representing the image height.
          */
-        u32 GetHeight() { return swapChainExtent.height; }
+        u32 GetHeight() const { return swapChainExtent.height; }
 
         static SwapChain* GetInstance() { return instance; }
 
@@ -233,6 +233,7 @@ namespace SnekVk
         VkExtent2D windowExtent;
 
         // frame buffers and renderpasses
+        // TODO: Refactor this into a HeapArray
         VkFramebuffer* swapChainFrameBuffers {VK_NULL_HANDLE};
         RenderPass renderPass;
 
@@ -250,6 +251,7 @@ namespace SnekVk
         VkSwapchainKHR swapChain {VK_NULL_HANDLE};
 
         // Synchronisation objects
+        // TODO: Refactor these into HeapArrays
         VkSemaphore* imageAvailableSemaphores {VK_NULL_HANDLE};
         VkSemaphore* renderFinishedSemaphores {VK_NULL_HANDLE};
         VkFence* inFlightFences {VK_NULL_HANDLE};

--- a/src/Renderer/Utils/StackArray.h
+++ b/src/Renderer/Utils/StackArray.h
@@ -33,6 +33,7 @@ namespace SnekVk::Utils
         ~StackArray() {}
 
         size_t Count() { return count; }
+        size_t Count() const { return count; }
         size_t Size() { return S; }
         T* Data() { return data; }
         const T* Data() const { return data; }


### PR DESCRIPTION
This is part of the Swapchain refactor process. The intention is to have an API for managing renderpasses and attachments.