### PR TITLE
[FIX] Fixed Windows Segfault

### DIFF
--- a/src/Renderer/Device/VulkanDevice.h
+++ b/src/Renderer/Device/VulkanDevice.h
@@ -271,7 +271,7 @@ namespace SnekVk {
 		/**
 		 * An array storing all required extensions. All of these must be present for the renderer to start.
 		 **/
-		const std::array<const char*, 1> deviceExtensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+		const std::array<const char*, 2> deviceExtensions = { VK_KHR_SWAPCHAIN_EXTENSION_NAME, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME };
 	};
 
 }  // namespace lve

--- a/src/Renderer/Material/Material.cpp
+++ b/src/Renderer/Material/Material.cpp
@@ -175,9 +175,8 @@ namespace SnekVk
 
             u64 offset = property.offset;
 
-            std::cout << property.size + offset << std::endl;
-
-            bufferInfos[i] = Utils::Descriptor::CreateBufferInfo(buffer.buffer, offset, property.size);
+            bufferInfos[i] = Utils::Descriptor::CreateBufferInfo(buffer.buffer, offset, property.size * property.count);
+            std::cout << "Property Size: " << property.size * property.count << std::endl;
 
             std::cout << "Allocating descriptor set for binding " << property.binding << std::endl;
             Utils::Descriptor::AllocateSets(device->Device(), &binding.descriptorSet, descriptorPool, 1, &binding.layout);
@@ -217,8 +216,8 @@ namespace SnekVk
                 VertexDescription::CreateBinding(
                 i, 
                 binding.vertexStride, 
-                VertexDescription::VERTEX, 
-                attributes.Data(), 
+                VertexDescription::VERTEX,
+                attributes.Data(),
                 attributes.Count()
             ));
         }
@@ -243,7 +242,7 @@ namespace SnekVk
                 uniform.id, 
                 (VkShaderStageFlags)shader->GetStage(), 
                 offset,  
-                uniform.size, 
+                uniform.size * uniform.arraySize,
                 uniform.dynamicCount
             };
 

--- a/src/Renderer/Mesh/Mesh.cpp
+++ b/src/Renderer/Mesh/Mesh.cpp
@@ -47,7 +47,7 @@ namespace SnekVk
 
         // TODO(Aryeh): Only create this if there actually are indices
         Buffer::CreateBuffer(
-            sizeof(u32) * MAX_INDICES,
+            indexSize * MAX_INDICES,
             VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
             // specifies that data is accessible on the CPU.
             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | 
@@ -99,12 +99,12 @@ namespace SnekVk
 
     void Mesh::CreateIndexBuffer(const u32* indices)
     {
-        VkDeviceSize bufferSize = sizeof(u32) * MAX_INDICES;
+        VkDeviceSize bufferSize = indexSize * MAX_INDICES;
 
-        Buffer::CopyData(globalIndexStagingBuffer, bufferSize, indices);
+        Buffer::CopyData(globalIndexStagingBuffer, indexSize * indexCount, indices);
 
         Buffer::CreateBuffer(
-            bufferSize,
+                bufferSize,
             VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
             // specifies that data is accessible on the CPU.
             VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,

--- a/src/Renderer/Mesh/Mesh.h
+++ b/src/Renderer/Mesh/Mesh.h
@@ -94,6 +94,7 @@ namespace SnekVk
         u32 indexCount = 0;
         u32 vertexCount = 0;
 
+        u64 indexSize {sizeof(u32)};
         u64 vertexSize = 0;
 
         bool isFreed = false;

--- a/src/Renderer/Renderers/Renderer2D.cpp
+++ b/src/Renderer/Renderers/Renderer2D.cpp
@@ -21,10 +21,11 @@ namespace SnekVk
 
     void Renderer2D::DrawModel(Model* model, const glm::vec2& position, const glm::vec2& scale, const float& rotation, const float& zIndex)
     {
-        models.Append(model);
+        Renderer2D::models.Append(model);
 
         auto transform = Utils::Math::CalculateTransform3D(glm::vec3(position.x, position.y, zIndex), glm::vec3(0.f, 0.f, rotation), glm::vec3(scale.x, scale.y, 0.f));
-        transforms.Append({ transform });
+
+        Renderer2D::transforms.Append({ transform });
     }
 
     void Renderer2D::DrawModel(Model* model, const glm::vec2& position, const glm::vec2& scale, const float& zIndex)
@@ -39,7 +40,7 @@ namespace SnekVk
 
     void Renderer2D::RecreateMaterials()
     {
-        if (currentMaterial) currentMaterial->RecreatePipeline(); 
+        if (currentMaterial != nullptr) currentMaterial->RecreatePipeline();
     }
 
     void Renderer2D::Render(VkCommandBuffer& commandBuffer, const GlobalData& globalData)
@@ -53,17 +54,16 @@ namespace SnekVk
             if (currentMaterial != model->GetMaterial())
             {
                 currentMaterial = model->GetMaterial();
-                currentMaterial->SetUniformData(transformId, transformSize, transforms.Data());
-                currentMaterial->SetUniformData(globalDataId, sizeof(globalData), &globalData);
+                currentMaterial->SetUniformData(Renderer2D::transformId, Renderer2D::transformSize, transforms.Data());
+                currentMaterial->SetUniformData(Renderer2D::globalDataId, sizeof(globalData), &globalData);
                 currentMaterial->Bind(commandBuffer);
-            } 
+            }
 
             if (currentModel != model)
             {
                 currentModel = model;
                 currentModel->Bind(commandBuffer);
             }
-
             model->Draw(commandBuffer, i);
         }
 

--- a/src/Renderer/Swapchain/Swapchain.h
+++ b/src/Renderer/Swapchain/Swapchain.h
@@ -247,7 +247,7 @@ namespace SnekVk
         FrameImages depthImages;
 
         // The raw Vulkan swapchain object
-        VkSwapchainKHR swapChain;
+        VkSwapchainKHR swapChain {VK_NULL_HANDLE};
 
         // Synchronisation objects
         VkSemaphore* imageAvailableSemaphores {VK_NULL_HANDLE};

--- a/src/Renderer/Utils/StackArray.h
+++ b/src/Renderer/Utils/StackArray.h
@@ -35,6 +35,7 @@ namespace SnekVk::Utils
         size_t Count() { return count; }
         size_t Size() { return S; }
         T* Data() { return data; }
+        const T* Data() const { return data; }
         
         void Set(size_t index, T value)
         {


### PR DESCRIPTION
Fixed an issue where Windows was segfaulting when trying to load in 3D objects. For some reason this issue was not reproducible in MacOS or Linux. This fixes the major issues with object buffers and re-enables the ability to render multiple 3D objects. 