### PR TITLE
[REFACTOR] Added a Fence Class for the Swapchain 

### DIFF
--- a/src/Renderer/Renderer.cpp
+++ b/src/Renderer/Renderer.cpp
@@ -139,7 +139,7 @@ namespace SnekVk
         SNEK_ASSERT(vkEndCommandBuffer(OUT commandBuffer) == VK_SUCCESS,
             "Failed to record command buffer!");
 
-        auto result = swapChain.SubmitCommandBuffers(&commandBuffer, &currentImageIndex);
+        auto result = swapChain.SubmitCommandBuffers(&commandBuffer, currentImageIndex);
 
         if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR ||
             window.WasResized())

--- a/src/Renderer/Swapchain/Swapchain.cpp
+++ b/src/Renderer/Swapchain/Swapchain.cpp
@@ -230,7 +230,7 @@ namespace SnekVk
         swapChainDepthFormat = format;
         VkExtent2D swapChainExtent = GetSwapChainExtent();
 
-        // Initialise our depth image information. 
+        // AllocateFences our depth image information.
         depthImages = FrameImages(&device, format);
 
         depthImages.InitDepthImageView2D(swapChainExtent.width, swapChainExtent.height, 1);
@@ -240,7 +240,7 @@ namespace SnekVk
     {
         u32 imageCount = FrameImages::GetImageCount();
 
-        // Initialise the framebuffers storage
+        // AllocateFences the framebuffers storage
         if (swapChainFrameBuffers == nullptr) swapChainFrameBuffers = new VkFramebuffer[imageCount];
 
         // We need a separate frame buffer for each image that we want to draw
@@ -276,8 +276,6 @@ namespace SnekVk
         
         if (imageAvailableSemaphores == nullptr) imageAvailableSemaphores = new VkSemaphore[MAX_FRAMES_IN_FLIGHT];
         if (renderFinishedSemaphores == nullptr) renderFinishedSemaphores = new VkSemaphore[MAX_FRAMES_IN_FLIGHT];
-        //if (inFlightFences == nullptr) inFlightFences = new VkFence[MAX_FRAMES_IN_FLIGHT];
-        //if (imagesInFlight == nullptr) imagesInFlight = new VkFence[imageCount];
 
         // Create our semaphore and fence create info
         VkSemaphoreCreateInfo semaphoreInfo{};
@@ -288,7 +286,8 @@ namespace SnekVk
         fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
         inFlightFences = Fence(MAX_FRAMES_IN_FLIGHT);
-        inFlightFences.Initialise();
+        inFlightFences.AllocateFences();
+
         imagesInFlight = Fence(imageCount);
 
         // Create the synchronisation objects

--- a/src/Renderer/Swapchain/Swapchain.h
+++ b/src/Renderer/Swapchain/Swapchain.h
@@ -3,6 +3,7 @@
 #include "../Device/VulkanDevice.h"
 #include "../RenderPass/RenderPass.h"
 #include "../Image/FrameImages.h"
+#include "../Synchronisation/Fence.h"
 
 namespace SnekVk
 {
@@ -133,7 +134,7 @@ namespace SnekVk
          * @param imageIndex - the index of the image being drawn. 
          * @return VkResult - the result of submitting the buffer. 
          */
-        VkResult SubmitCommandBuffers(const VkCommandBuffer* buffers, u32* imageIndex);
+        VkResult SubmitCommandBuffers(const VkCommandBuffer* buffers, const u32& imageIndex);
 
         void RecreateSwapchain();
 
@@ -252,8 +253,10 @@ namespace SnekVk
         // Synchronisation objects
         VkSemaphore* imageAvailableSemaphores {VK_NULL_HANDLE};
         VkSemaphore* renderFinishedSemaphores {VK_NULL_HANDLE};
-        VkFence* inFlightFences {VK_NULL_HANDLE};
-        VkFence* imagesInFlight {VK_NULL_HANDLE};
+        //VkFence* inFlightFences {VK_NULL_HANDLE};
+
+        Fence inFlightFences;
+        Fence imagesInFlight;
         size_t currentFrame = 0;
     };
 }

--- a/src/Renderer/Synchronisation/Fence.cpp
+++ b/src/Renderer/Synchronisation/Fence.cpp
@@ -1,0 +1,50 @@
+#include "Fence.h"
+#include "../Device/VulkanDevice.h"
+
+namespace SnekVk
+{
+    Fence::Fence(const u32& fenceCount)
+        : fences{Utils::Array<VkFence>(fenceCount)}
+    {
+        for(auto& fence: fences) fence = VK_NULL_HANDLE;
+    }
+
+    void Fence::DestroyFence() {
+        auto device = VulkanDevice::GetDeviceInstance();
+
+        for(auto& fence : fences) vkDestroyFence(device->Device(), fence, nullptr);
+    }
+
+    void Fence::WaitForFence(const u32& index, const u64& timeout) {
+        auto* device = VulkanDevice::GetDeviceInstance();
+
+        vkWaitForFences(device->Device(), 1, &fences[index], VK_TRUE, timeout);
+    }
+
+    void Fence::SetFence(const u32& index, const VkFence& fence) {
+        fences[index] = fence;
+    }
+
+    const VkFence &Fence::GetFence(const u32 &index) const {
+        return fences[index];
+    }
+
+    VkFence &Fence::GetFence(const u32 &index) {
+        return fences[index];
+    }
+
+    void Fence::Initialise() {
+        auto* device = VulkanDevice::GetDeviceInstance();
+
+        VkFenceCreateInfo fenceInfo{};
+        fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+
+        for(auto& fence : fences)
+        {
+            SNEK_ASSERT(vkCreateFence(device->Device(), &fenceInfo, nullptr, OUT &fence) == VK_SUCCESS,
+                        "Failed to create fences!");
+        }
+    }
+}
+

--- a/src/Renderer/Synchronisation/Fence.cpp
+++ b/src/Renderer/Synchronisation/Fence.cpp
@@ -33,11 +33,12 @@ namespace SnekVk
         return fences[index];
     }
 
-    void Fence::Initialise() {
+    void Fence::AllocateFences() {
         auto* device = VulkanDevice::GetDeviceInstance();
 
         VkFenceCreateInfo fenceInfo{};
         fenceInfo.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+        // create all fences in a signalled state
         fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
 
         for(auto& fence : fences)

--- a/src/Renderer/Synchronisation/Fence.h
+++ b/src/Renderer/Synchronisation/Fence.h
@@ -1,0 +1,28 @@
+#ifndef SNEK_FENCE_H
+#define SNEK_FENCE_H
+
+#include "../Core.h"
+
+namespace SnekVk
+{
+    class Fence {
+    public:
+        explicit Fence(const u32& fenceCount);
+
+        Fence() = default;
+        ~Fence() = default;
+
+        void Initialise();
+        void DestroyFence();
+        void WaitForFence(const u32& index, const u64& timeout = std::numeric_limits<u64>::max());
+        void SetFence(const u32& index, const VkFence& fence);
+        const VkFence& GetFence(const u32& index) const;
+        VkFence& GetFence(const u32& index);
+
+    private:
+        Utils::Array<VkFence> fences;
+    };
+
+}
+
+#endif //SNEK_FENCE_H

--- a/src/Renderer/Synchronisation/Fence.h
+++ b/src/Renderer/Synchronisation/Fence.h
@@ -5,18 +5,75 @@
 
 namespace SnekVk
 {
+    /**
+     * @brief The fence class is a SOA class for storing per-frame fences. This class is intended to store multiple
+     * vulkan fences which can be awaited by passing in an appropriate index. This structure can be seen as a managed array
+     * which enables you to access fences within certain positions and then wait on them.
+     *
+     * By default, no memory is allocated from Vulkan. The reason for this is that sometimes we just want a storage
+     * which doesn't create a new fence, but rather just stores an existing one.
+     *
+     * This class requires memorhy to be manually deallocated via the DestroyFence method.
+     */
     class Fence {
     public:
+        /**
+         * @brief A constructor for creating the Fence collection and allocating the number of fences needed. This
+         * constructor will allocate the memory needed to store a number of fences equal to fenceCount.
+         * @param fenceCount the number of fences to be stored in this collection.
+         */
         explicit Fence(const u32& fenceCount);
 
+        /**
+         * @brief Default constructor for the Fence class. This constructor allocates no memory and will create an
+         * empty array.
+         */
         Fence() = default;
+
+        /**
+         * @brief Default destructor for the Fence class. This destructor does nothing. All deallocation logic occurs
+         * in the DestroyFence function.
+         */
         ~Fence() = default;
 
-        void Initialise();
+        /**
+         * @brief Allocates the fences from Vulkan. This will allocate the fences for every element in the array.
+         */
+        void AllocateFences();
+
+        /**
+         * @brief Deallocates the fences.
+         */
         void DestroyFence();
+
+        /**
+         * @brief Wait for a fence in the collection to become signaled.
+         * @param index the index of the fence we want to wait for.
+         * @param timeout an amount of time to wait before we stop waiting. By default thios is set to the maximum value
+         * of a 64 bit unsigned integer.
+         */
         void WaitForFence(const u32& index, const u64& timeout = std::numeric_limits<u64>::max());
+
+        /**
+         * @brief Sets the value of the fence at the specified index. This should be used if you want to store an allocated
+         * fence into the collection.
+         * @param index the position you want to store the fence in.
+         * @param fence the VkFence you want to store in the container.
+         */
         void SetFence(const u32& index, const VkFence& fence);
+
+        /**
+         * @brief Gets the fence stored in the location specified by the index variable.
+         * @param index the index of the fence you want to get.
+         * @return the fence stored at the specified index.
+         */
         const VkFence& GetFence(const u32& index) const;
+
+        /**
+         * @brief Gets the fence stored in the location specified by the index variable.
+         * @param index the index of the fence you want to get.
+         * @return the fence stored at the specified index.
+         */
         VkFence& GetFence(const u32& index);
 
     private:

--- a/src/Renderer/Utils/Array.h
+++ b/src/Renderer/Utils/Array.h
@@ -142,6 +142,8 @@ namespace SnekVk::Utils
         }
 
         const size_t Size() const { return size; }
+
+        // TODO(Aryeh): Actually change the size of the array
         void SetSize(size_t size) { this->size = size; }
 
         T& operator[] (size_t index) { return data[index]; }


### PR DESCRIPTION
Vulkan synchronisation must occur every frame. Part of the synchronisation process requires us to use a set of fences. This class is used to allow multiple fences to be allocated and stored. 